### PR TITLE
fix: bounds validation for gain map, MPF parsing, and XMP limits

### DIFF
--- a/ultrahdr-core/src/color/tonemap.rs
+++ b/ultrahdr-core/src/color/tonemap.rs
@@ -1070,6 +1070,10 @@ impl AdaptiveTonemapper {
             });
         }
 
+        // Validate pixel data is large enough for declared dimensions
+        hdr.validate_data_bounds()?;
+        sdr.validate_data_bounds()?;
+
         match config.mode {
             FitMode::Luminance => Self::fit_luminance(hdr, sdr, config),
             FitMode::PerChannel => Self::fit_per_channel(hdr, sdr, config),
@@ -1091,6 +1095,9 @@ impl AdaptiveTonemapper {
 
     /// Apply the tonemapper to an HDR image.
     pub fn apply(&self, hdr: &RawImage) -> Result<RawImage> {
+        // Validate pixel data is large enough for declared dimensions
+        hdr.validate_data_bounds()?;
+
         let width = hdr.width;
         let height = hdr.height;
 
@@ -1671,8 +1678,11 @@ pub fn tonemap_to_srgb8(
 /// Tonemap an entire HDR image to SDR RGBA8.
 ///
 /// Takes an HDR image in any supported format and produces RGBA8 output.
-pub fn tonemap_image_to_srgb8(img: &RawImage, target_gamut: ColorGamut) -> Vec<u8> {
+pub fn tonemap_image_to_srgb8(img: &RawImage, target_gamut: ColorGamut) -> Result<Vec<u8>> {
     use crate::color::gamut::convert_gamut;
+
+    // Validate pixel data is large enough for declared dimensions
+    img.validate_data_bounds()?;
 
     let config = ToneMapConfig::default();
     let width = img.width as usize;
@@ -1709,7 +1719,7 @@ pub fn tonemap_image_to_srgb8(img: &RawImage, target_gamut: ColorGamut) -> Vec<u
         }
     }
 
-    output
+    Ok(output)
 }
 
 // ============================================================================

--- a/ultrahdr-core/src/gainmap/apply.rs
+++ b/ultrahdr-core/src/gainmap/apply.rs
@@ -110,6 +110,9 @@ pub fn apply_gainmap(
     output_format: HdrOutputFormat,
     stop: impl Stop,
 ) -> Result<RawImage> {
+    // Validate pixel data is large enough for declared dimensions
+    sdr.validate_data_bounds()?;
+
     let width = sdr.width;
     let height = sdr.height;
 

--- a/ultrahdr-core/src/gainmap/compute.rs
+++ b/ultrahdr-core/src/gainmap/compute.rs
@@ -74,6 +74,10 @@ pub fn compute_gainmap(
         });
     }
 
+    // Validate pixel data is large enough for declared dimensions
+    hdr.validate_data_bounds()?;
+    sdr.validate_data_bounds()?;
+
     let scale = config.scale_factor.max(1) as u32;
     let gm_width = hdr.width.div_ceil(scale);
     let gm_height = hdr.height.div_ceil(scale);

--- a/ultrahdr-core/src/metadata/xmp.rs
+++ b/ultrahdr-core/src/metadata/xmp.rs
@@ -171,6 +171,15 @@ fn format_f64_value(values: &[f64; 3], single_channel: bool) -> String {
 /// Returns `(metadata, gainmap_length)` for backward compatibility.
 /// For access to all container items (depth maps, etc.), use [`parse_xmp_full`].
 pub fn parse_xmp(xmp_data: &str) -> Result<(GainMapMetadata, Option<usize>)> {
+    // Enforce maximum XMP length to prevent CPU exhaustion on crafted input
+    if xmp_data.len() > crate::limits::MAX_XMP_LENGTH {
+        return Err(Error::LimitExceeded(alloc::format!(
+            "XMP data length {} exceeds maximum {}",
+            xmp_data.len(),
+            crate::limits::MAX_XMP_LENGTH
+        )));
+    }
+
     // Check for hdrgm:Version
     if !xmp_data.contains("hdrgm:Version") && !xmp_data.contains("hdrgm:GainMapMax") {
         return Err(Error::NotUltraHdr);

--- a/ultrahdr-core/src/types.rs
+++ b/ultrahdr-core/src/types.rs
@@ -304,6 +304,27 @@ impl RawImage {
         Ok(())
     }
 
+    /// Validate that pixel data is large enough for declared dimensions.
+    ///
+    /// This should be called at entry points that iterate over pixel data
+    /// (e.g., gain map apply/compute, tonemapping) to prevent OOB panics
+    /// when stride or dimensions are inconsistent with data length.
+    pub fn validate_data_bounds(&self) -> Result<()> {
+        let required =
+            Self::calculate_data_size(self.width, self.height, self.stride, self.format)?;
+        if self.data.len() < required {
+            return Err(Error::InvalidPixelData(format!(
+                "data too small for {}x{} {:?}: need {} bytes, have {}",
+                self.width,
+                self.height,
+                self.format,
+                required,
+                self.data.len()
+            )));
+        }
+        Ok(())
+    }
+
     /// Calculate required data size with overflow checking.
     fn calculate_data_size(
         _width: u32,

--- a/ultrahdr-rs/src/container.rs
+++ b/ultrahdr-rs/src/container.rs
@@ -359,12 +359,21 @@ pub fn parse_mpf_segment(data: &[u8], mpf_marker_offset: usize) -> Result<MpfDir
         }
     }
 
+    // Cap entry count against actual data size to prevent OOM from crafted inputs.
+    // Each MP entry is 16 bytes; also cap at a sane maximum of 1000 images.
+    let max_possible = if mp_entry_offset > 0 && mp_entry_offset < mpf_data.len() {
+        (mpf_data.len() - mp_entry_offset) / 16
+    } else {
+        0
+    };
+    let mp_entry_count = (mp_entry_count as usize).min(max_possible).min(1000);
+
     // Parse MP Entry array
-    let mut entries = Vec::with_capacity(mp_entry_count as usize);
+    let mut entries = Vec::with_capacity(mp_entry_count);
 
     if mp_entry_offset > 0 && mp_entry_count > 0 {
         for i in 0..mp_entry_count {
-            let entry_pos = mp_entry_offset + (i as usize) * 16;
+            let entry_pos = mp_entry_offset + i * 16;
             if entry_pos + 16 > mpf_data.len() {
                 break;
             }
@@ -382,7 +391,7 @@ pub fn parse_mpf_segment(data: &[u8], mpf_marker_offset: usize) -> Result<MpfDir
                 image_type: MpfImageType::from_attribute(attr),
                 size,
                 offset,
-                index: i,
+                index: i as u32,
             });
         }
     }

--- a/ultrahdr-rs/src/encode.rs
+++ b/ultrahdr-rs/src/encode.rs
@@ -280,7 +280,7 @@ impl Encoder {
             } else if let Some(ref sdr_img) = self.sdr_image {
                 (self.encode_base_jpeg(sdr_img)?, sdr_img.gamut)
             } else if let Some(ref hdr) = self.hdr_image {
-                let sdr_pixels = tonemap_image_to_srgb8(hdr, ColorGamut::Bt709);
+                let sdr_pixels = tonemap_image_to_srgb8(hdr, ColorGamut::Bt709)?;
                 let sdr = RawImage {
                     width: hdr.width,
                     height: hdr.height,
@@ -310,7 +310,7 @@ impl Encoder {
         let sdr = if let Some(ref sdr_img) = self.sdr_image {
             sdr_img.clone()
         } else {
-            let sdr_pixels = tonemap_image_to_srgb8(hdr, ColorGamut::Bt709);
+            let sdr_pixels = tonemap_image_to_srgb8(hdr, ColorGamut::Bt709)?;
             RawImage {
                 width: hdr.width,
                 height: hdr.height,


### PR DESCRIPTION
## Summary
- Add dimension/stride validation before pixel access in gain map apply/compute and tonemap (prevents OOB panic on mismatched image data)
- Cap MPF entry count against actual data size to prevent OOM on crafted inputs (was allocating based on untrusted u32 count)
- Enforce MAX_XMP_LENGTH limit in parse_xmp (16 MB constant was defined but never checked)

## Test plan
- [x] Existing tests pass (215 pass, 3 pre-existing failures unrelated to this change)
- [ ] Malformed inputs return errors instead of panicking