### PR TITLE
feat(ultrahdr-core): Shepard's IDW upsample for gain map apply

### DIFF
--- a/ultrahdr-core/benches/gainmap.rs
+++ b/ultrahdr-core/benches/gainmap.rs
@@ -4,11 +4,12 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use std::hint::black_box;
 use ultrahdr_core::{
     ColorPrimaries, GainMap, GainMapChannel, GainMapMetadata, PixelBuffer, PixelFormat,
-    TransferFunction, new_pixel_buffer,
+    TransferFunction,
     gainmap::{
         apply::{HdrOutputFormat, apply_gainmap},
         compute::{GainMapConfig, compute_gainmap},
     },
+    new_pixel_buffer,
 };
 
 /// Create a test SDR image of given dimensions.
@@ -134,7 +135,6 @@ fn bench_apply_gainmap(c: &mut Criterion) {
                 });
             },
         );
-
     }
 
     group.finish();

--- a/ultrahdr-core/src/color/tonemap.rs
+++ b/ultrahdr-core/src/color/tonemap.rs
@@ -1055,10 +1055,7 @@ pub fn tonemap_to_srgb8(
 /// Tonemap an entire HDR image to SDR RGBA8.
 ///
 /// Takes an HDR image in any supported format and produces RGBA8 output.
-pub fn tonemap_image_to_srgb8(
-    img: &PixelBuffer,
-    target_gamut: ColorPrimaries,
-) -> Result<Vec<u8>> {
+pub fn tonemap_image_to_srgb8(img: &PixelBuffer, target_gamut: ColorPrimaries) -> Result<Vec<u8>> {
     use crate::color::gamut::convert_gamut;
 
     let slice = img.as_slice();
@@ -1129,18 +1126,10 @@ fn get_linear_rgb(img: &PixelSlice<'_>, x: u32, y: u32) -> [f32; 3] {
         PixelFormat::RgbaF32 => {
             let idx = (y as usize) * stride + (x as usize) * 16;
             let r = f32::from_le_bytes([data[idx], data[idx + 1], data[idx + 2], data[idx + 3]]);
-            let g = f32::from_le_bytes([
-                data[idx + 4],
-                data[idx + 5],
-                data[idx + 6],
-                data[idx + 7],
-            ]);
-            let b = f32::from_le_bytes([
-                data[idx + 8],
-                data[idx + 9],
-                data[idx + 10],
-                data[idx + 11],
-            ]);
+            let g =
+                f32::from_le_bytes([data[idx + 4], data[idx + 5], data[idx + 6], data[idx + 7]]);
+            let b =
+                f32::from_le_bytes([data[idx + 8], data[idx + 9], data[idx + 10], data[idx + 11]]);
             [r, g, b]
         }
         _ => [0.5, 0.5, 0.5],

--- a/ultrahdr-core/src/gainmap/apply.rs
+++ b/ultrahdr-core/src/gainmap/apply.rs
@@ -114,7 +114,14 @@ pub fn apply_gainmap(
     stop: impl Stop,
 ) -> Result<PixelBuffer> {
     let sdr_slice = sdr.as_slice();
-    apply_gainmap_slice(sdr_slice, gainmap, metadata, display_boost, output_format, stop)
+    apply_gainmap_slice(
+        sdr_slice,
+        gainmap,
+        metadata,
+        display_boost,
+        output_format,
+        stop,
+    )
 }
 
 /// [`apply_gainmap`] variant that takes a borrowed [`PixelSlice`] directly.
@@ -141,6 +148,11 @@ pub fn apply_gainmap_slice(
 
     // Create precomputed LUT for fast gain decoding
     let lut = GainMapLut::new(metadata, weight);
+
+    // Build the Shepard's weight table if image-to-gainmap ratio is integer
+    // (the common case — ISO 21496-1 maps are typically 1/2, 1/4, 1/8, 1/16).
+    // `None` means we fall back to per-pixel sqrt with row-hoisted constants.
+    let shepards = ShepardsLut::try_new(width, height, gainmap.width, gainmap.height);
 
     // Create output image
     let mut output = match output_format {
@@ -189,7 +201,15 @@ pub fn apply_gainmap_slice(
         stop.check()?;
 
         read_sdr_row_linear(&sdr, y, &mut sdr_row);
-        sample_gainmap_row_lut(gainmap, &lut, y, width, height, &mut gains_row);
+        sample_gainmap_row_lut(
+            gainmap,
+            &lut,
+            shepards.as_ref(),
+            y,
+            width,
+            height,
+            &mut gains_row,
+        );
         super::apply_simd::apply_gain_row_presampled(
             &sdr_row,
             &gains_row,
@@ -216,21 +236,29 @@ fn read_sdr_row_linear(sdr: &PixelSlice<'_>, y: u32, out: &mut [[f32; 3]]) {
     }
 }
 
-/// Sample a full row of gains from the gain map (bilinear, LUT-accelerated).
+/// Sample a full row of gains from the gain map (Shepard's IDW, LUT-accelerated).
 ///
 /// `out.len()` must equal `img_width as usize`. For single-channel gain maps,
 /// the same gain is broadcast to R/G/B.
+///
+/// `shepards` MUST be `Some(_)` when `img_width % gainmap.width == 0` and
+/// `img_height % gainmap.height == 0`; the caller builds it once via
+/// [`ShepardsLut::try_new`] and passes it to every row. When `None`, the
+/// per-pixel sqrt fallback runs (still computes weights once per pixel and
+/// shares them across channels).
 pub(crate) fn sample_gainmap_row_lut(
     gainmap: &GainMap,
     lut: &GainMapLut,
+    shepards: Option<&ShepardsLut>,
     y: u32,
     img_width: u32,
     img_height: u32,
     out: &mut [[f32; 3]],
 ) {
     debug_assert_eq!(out.len(), img_width as usize);
-    for (x, gain) in out.iter_mut().enumerate() {
-        *gain = sample_gainmap_lut(gainmap, lut, x as u32, y, img_width, img_height);
+    match shepards {
+        Some(shep) => sample_row_lut_int(gainmap, lut, shep, y, out),
+        None => sample_row_lut_float(gainmap, lut, y, img_width, img_height, out),
     }
 }
 
@@ -306,18 +334,10 @@ fn get_sdr_linear(sdr: &PixelSlice<'_>, x: u32, y: u32) -> [f32; 3] {
         PixelFormat::RgbaF32 => {
             let idx = (y as usize) * stride + (x as usize) * 16;
             let r = f32::from_le_bytes([data[idx], data[idx + 1], data[idx + 2], data[idx + 3]]);
-            let g = f32::from_le_bytes([
-                data[idx + 4],
-                data[idx + 5],
-                data[idx + 6],
-                data[idx + 7],
-            ]);
-            let b = f32::from_le_bytes([
-                data[idx + 8],
-                data[idx + 9],
-                data[idx + 10],
-                data[idx + 11],
-            ]);
+            let g =
+                f32::from_le_bytes([data[idx + 4], data[idx + 5], data[idx + 6], data[idx + 7]]);
+            let b =
+                f32::from_le_bytes([data[idx + 8], data[idx + 9], data[idx + 10], data[idx + 11]]);
             [r, g, b]
         }
         PixelFormat::Gray8 => {
@@ -329,70 +349,316 @@ fn get_sdr_linear(sdr: &PixelSlice<'_>, x: u32, y: u32) -> [f32; 3] {
     }
 }
 
-/// Bilinear interpolation.
-#[inline(always)]
-fn bilinear(v00: f32, v10: f32, v01: f32, v11: f32, fx: f32, fy: f32) -> f32 {
-    let top = v00 * (1.0 - fx) + v10 * fx;
-    let bottom = v01 * (1.0 - fx) + v11 * fx;
-    top * (1.0 - fy) + bottom * fy
+/// Precomputed Shepard's IDW weight tables for integer-scale gain map upsample.
+///
+/// Mirrors libultrahdr's `ShepardsIDW` struct (see `gainmapmath.h:228`,
+/// `gainmapmath.cpp:49`). Per-pixel sample-time work drops from "4 sqrt
+/// plus 4 div" to "4 mul plus 3 add" by precomputing weights for every
+/// distinct sub-pixel position in the unit cell. Holds four tables
+/// (interior, no-right edge, no-bottom edge, corner) to handle gain-map
+/// boundary clamping without per-pixel branches on bounds.
+///
+/// Only valid when image dimensions are an integer multiple of gain-map
+/// dimensions. Storage is `4 * scale_x * scale_y * 4` floats (≤ 16 KB
+/// for any sane scale).
+#[derive(Debug)]
+pub struct ShepardsLut {
+    scale_x: u32,
+    scale_y: u32,
+    /// Indexed `[oy * scale_x + ox] * 4 + corner` where corner is
+    /// 0=TL, 1=BL, 2=TR, 3=BR. Same memory layout in all four tables.
+    full: Box<[f32]>,
+    no_right: Box<[f32]>,
+    no_bottom: Box<[f32]>,
+    corner: Box<[f32]>,
 }
 
-/// Sample gain map with bilinear interpolation using precomputed LUT.
-///
-/// This is significantly faster than `sample_gainmap` because it uses LUT lookups
-/// instead of expensive `powf()` and `exp()` calls per pixel.
-#[inline]
-#[allow(clippy::needless_range_loop)] // c is used as both index and channel parameter
-fn sample_gainmap_lut(
-    gainmap: &GainMap,
-    lut: &GainMapLut,
-    x: u32,
-    y: u32,
-    img_width: u32,
-    img_height: u32,
-) -> [f32; 3] {
-    // Map image coordinates to gain map coordinates
-    let gm_x = (x as f32 / img_width as f32) * gainmap.width as f32;
-    let gm_y = (y as f32 / img_height as f32) * gainmap.height as f32;
-
-    // Bilinear interpolation coordinates
-    let x0 = (gm_x.floor() as u32).min(gainmap.width - 1);
-    let y0 = (gm_y.floor() as u32).min(gainmap.height - 1);
-    let x1 = (x0 + 1).min(gainmap.width - 1);
-    let y1 = (y0 + 1).min(gainmap.height - 1);
-
-    let fx = gm_x - gm_x.floor();
-    let fy = gm_y - gm_y.floor();
-
-    if gainmap.channels == 1 {
-        // Single channel - look up gains from LUT, then interpolate
-        let g00 = lut.lookup(gainmap.data[(y0 * gainmap.width + x0) as usize], 0);
-        let g10 = lut.lookup(gainmap.data[(y0 * gainmap.width + x1) as usize], 0);
-        let g01 = lut.lookup(gainmap.data[(y1 * gainmap.width + x0) as usize], 0);
-        let g11 = lut.lookup(gainmap.data[(y1 * gainmap.width + x1) as usize], 0);
-
-        let gain = bilinear(g00, g10, g01, g11, fx, fy);
-        [gain, gain, gain]
-    } else {
-        // Multi-channel - look up and interpolate each channel
-        let mut gains = [0.0f32; 3];
-        for c in 0..3 {
-            let idx00 = (y0 * gainmap.width + x0) as usize * 3 + c;
-            let idx10 = (y0 * gainmap.width + x1) as usize * 3 + c;
-            let idx01 = (y1 * gainmap.width + x0) as usize * 3 + c;
-            let idx11 = (y1 * gainmap.width + x1) as usize * 3 + c;
-
-            let g00 = lut.lookup(gainmap.data[idx00], c);
-            let g10 = lut.lookup(gainmap.data[idx10], c);
-            let g01 = lut.lookup(gainmap.data[idx01], c);
-            let g11 = lut.lookup(gainmap.data[idx11], c);
-
-            gains[c] = bilinear(g00, g10, g01, g11, fx, fy);
+impl ShepardsLut {
+    /// Build weight tables for an arbitrary integer scale (`scale_x`, `scale_y`).
+    /// Most callers should use [`Self::try_new`] which infers the scale from
+    /// image and gain-map dimensions.
+    pub fn new(scale_x: u32, scale_y: u32) -> Self {
+        debug_assert!(scale_x >= 1 && scale_y >= 1);
+        let n = (scale_x * scale_y * 4) as usize;
+        let mut full = vec![0.0f32; n].into_boxed_slice();
+        let mut no_right = vec![0.0f32; n].into_boxed_slice();
+        let mut no_bottom = vec![0.0f32; n].into_boxed_slice();
+        let mut corner = vec![0.0f32; n].into_boxed_slice();
+        fill_shepards(&mut full, scale_x, scale_y, 1, 1);
+        fill_shepards(&mut no_right, scale_x, scale_y, 0, 1);
+        fill_shepards(&mut no_bottom, scale_x, scale_y, 1, 0);
+        fill_shepards(&mut corner, scale_x, scale_y, 0, 0);
+        Self {
+            scale_x,
+            scale_y,
+            full,
+            no_right,
+            no_bottom,
+            corner,
         }
-        gains
+    }
+
+    /// Build a LUT iff image dims are an exact integer multiple of gain-map
+    /// dims. `None` means the caller must take the per-pixel sqrt fallback.
+    pub fn try_new(img_width: u32, img_height: u32, gm_width: u32, gm_height: u32) -> Option<Self> {
+        if gm_width == 0 || gm_height == 0 {
+            return None;
+        }
+        if !img_width.is_multiple_of(gm_width) || !img_height.is_multiple_of(gm_height) {
+            return None;
+        }
+        let sx = img_width / gm_width;
+        let sy = img_height / gm_height;
+        if sx == 0 || sy == 0 {
+            return None;
+        }
+        Some(Self::new(sx, sy))
+    }
+
+    #[inline(always)]
+    fn pick(&self, no_right: bool, no_bottom: bool) -> &[f32] {
+        match (no_right, no_bottom) {
+            (false, false) => &self.full,
+            (true, false) => &self.no_right,
+            (false, true) => &self.no_bottom,
+            (true, true) => &self.corner,
+        }
     }
 }
 
+fn fill_shepards(weights: &mut [f32], sx: u32, sy: u32, inc_r: u32, inc_b: u32) {
+    let sx_f = sx as f32;
+    let sy_f = sy as f32;
+    for y in 0..sy {
+        for x in 0..sx {
+            let pos_x = x as f32 / sx_f;
+            let pos_y = y as f32 / sy_f;
+            let next_x = inc_r as f32;
+            let next_y = inc_b as f32;
+            let idx = ((y * sx + x) * 4) as usize;
+            let d_tl = (pos_x * pos_x + pos_y * pos_y).sqrt();
+            if d_tl == 0.0 {
+                weights[idx] = 1.0;
+                weights[idx + 1] = 0.0;
+                weights[idx + 2] = 0.0;
+                weights[idx + 3] = 0.0;
+                continue;
+            }
+            let dy_b = pos_y - next_y;
+            let dx_r = pos_x - next_x;
+            let d_bl = (pos_x * pos_x + dy_b * dy_b).sqrt();
+            let d_tr = (dx_r * dx_r + pos_y * pos_y).sqrt();
+            let d_br = (dx_r * dx_r + dy_b * dy_b).sqrt();
+            let w_tl = 1.0 / d_tl;
+            let w_bl = 1.0 / d_bl;
+            let w_tr = 1.0 / d_tr;
+            let w_br = 1.0 / d_br;
+            let inv_total = 1.0 / (w_tl + w_bl + w_tr + w_br);
+            weights[idx] = w_tl * inv_total;
+            weights[idx + 1] = w_bl * inv_total;
+            weights[idx + 2] = w_tr * inv_total;
+            weights[idx + 3] = w_br * inv_total;
+        }
+    }
+}
+
+/// Shepard's IDW on 4 corners with weights computed in-place.
+///
+/// Used as the per-pixel fallback when the image-to-gain-map ratio is
+/// non-integer (so the precomputed LUT can't be used). Weights are
+/// computed once and reused across channels by callers.
+#[inline(always)]
+fn shepards_weights(fx: f32, fy: f32) -> [f32; 4] {
+    let dx_r = 1.0 - fx;
+    let dy_b = 1.0 - fy;
+    let d_tl = (fx * fx + fy * fy).sqrt();
+    if d_tl == 0.0 {
+        return [1.0, 0.0, 0.0, 0.0];
+    }
+    let d_bl = (fx * fx + dy_b * dy_b).sqrt();
+    if d_bl == 0.0 {
+        return [0.0, 1.0, 0.0, 0.0];
+    }
+    let d_tr = (dx_r * dx_r + fy * fy).sqrt();
+    if d_tr == 0.0 {
+        return [0.0, 0.0, 1.0, 0.0];
+    }
+    let d_br = (dx_r * dx_r + dy_b * dy_b).sqrt();
+    if d_br == 0.0 {
+        return [0.0, 0.0, 0.0, 1.0];
+    }
+    let w_tl = 1.0 / d_tl;
+    let w_bl = 1.0 / d_bl;
+    let w_tr = 1.0 / d_tr;
+    let w_br = 1.0 / d_br;
+    let inv_total = 1.0 / (w_tl + w_bl + w_tr + w_br);
+    [
+        w_tl * inv_total,
+        w_bl * inv_total,
+        w_tr * inv_total,
+        w_br * inv_total,
+    ]
+}
+
+#[inline(always)]
+fn dot4(c: [f32; 4], w: [f32; 4]) -> f32 {
+    c[0] * w[0] + c[1] * w[1] + c[2] * w[2] + c[3] * w[3]
+}
+
+/// Fast integer-scale row sampler. Picks weights from `shepards`
+/// (no per-pixel sqrt/div) and shares them across channels.
+fn sample_row_lut_int(
+    gainmap: &GainMap,
+    lut: &GainMapLut,
+    shepards: &ShepardsLut,
+    y: u32,
+    out: &mut [[f32; 3]],
+) {
+    let sx = shepards.scale_x;
+    let sy = shepards.scale_y;
+    let gw = gainmap.width;
+    let gh = gainmap.height;
+    debug_assert!(gw > 0 && gh > 0);
+
+    // Row-constant pieces: y0/y1 = enclosing gainmap rows; oy = sub-pixel
+    // offset; no_bottom = row sits at the gainmap's bottom edge so y1 was
+    // clamped back to y0.
+    let y0 = (y / sy).min(gh - 1);
+    let y1 = (y0 + 1).min(gh - 1);
+    let oy = y % sy;
+    let no_bottom = y0 == y1;
+
+    let row0_off = (y0 * gw) as usize;
+    let row1_off = (y1 * gw) as usize;
+
+    if gainmap.channels == 1 {
+        for (x_out, gain) in out.iter_mut().enumerate() {
+            let x = x_out as u32;
+            let x0 = (x / sx).min(gw - 1);
+            let x1 = (x0 + 1).min(gw - 1);
+            let ox = x % sx;
+            let no_right = x0 == x1;
+
+            let table = shepards.pick(no_right, no_bottom);
+            let base = ((oy * sx + ox) * 4) as usize;
+            let w = [
+                table[base],
+                table[base + 1],
+                table[base + 2],
+                table[base + 3],
+            ];
+
+            let g_tl = lut.lookup(gainmap.data[row0_off + x0 as usize], 0);
+            let g_bl = lut.lookup(gainmap.data[row1_off + x0 as usize], 0);
+            let g_tr = lut.lookup(gainmap.data[row0_off + x1 as usize], 0);
+            let g_br = lut.lookup(gainmap.data[row1_off + x1 as usize], 0);
+            let g = dot4([g_tl, g_bl, g_tr, g_br], w);
+            *gain = [g, g, g];
+        }
+    } else {
+        for (x_out, gain) in out.iter_mut().enumerate() {
+            let x = x_out as u32;
+            let x0 = (x / sx).min(gw - 1);
+            let x1 = (x0 + 1).min(gw - 1);
+            let ox = x % sx;
+            let no_right = x0 == x1;
+
+            let table = shepards.pick(no_right, no_bottom);
+            let base = ((oy * sx + ox) * 4) as usize;
+            let w = [
+                table[base],
+                table[base + 1],
+                table[base + 2],
+                table[base + 3],
+            ];
+
+            let tl = (row0_off + x0 as usize) * 3;
+            let bl = (row1_off + x0 as usize) * 3;
+            let tr = (row0_off + x1 as usize) * 3;
+            let br = (row1_off + x1 as usize) * 3;
+            for (c, dst) in gain.iter_mut().enumerate() {
+                let corners = [
+                    lut.lookup(gainmap.data[tl + c], c),
+                    lut.lookup(gainmap.data[bl + c], c),
+                    lut.lookup(gainmap.data[tr + c], c),
+                    lut.lookup(gainmap.data[br + c], c),
+                ];
+                *dst = dot4(corners, w);
+            }
+        }
+    }
+}
+
+/// Non-integer scale fallback. Computes weights once per pixel (4 sqrt
+/// plus 1 reciprocal-divide) and shares them across channels. Hoists
+/// `gm_y`/`y0`/`y1`/`fy` to row constants.
+fn sample_row_lut_float(
+    gainmap: &GainMap,
+    lut: &GainMapLut,
+    y: u32,
+    img_width: u32,
+    img_height: u32,
+    out: &mut [[f32; 3]],
+) {
+    let gw = gainmap.width;
+    let gh = gainmap.height;
+    debug_assert!(gw > 0 && gh > 0);
+    debug_assert!(img_width > 0 && img_height > 0);
+
+    let inv_iw = 1.0 / img_width as f32;
+    let inv_ih = 1.0 / img_height as f32;
+    let gw_f = gw as f32;
+    let gh_f = gh as f32;
+
+    let gm_y = (y as f32 * inv_ih) * gh_f;
+    let gm_y_floor = gm_y.floor();
+    let y0 = (gm_y_floor as u32).min(gh - 1);
+    let y1 = (y0 + 1).min(gh - 1);
+    let fy = gm_y - gm_y_floor;
+    let row0_off = (y0 * gw) as usize;
+    let row1_off = (y1 * gw) as usize;
+
+    if gainmap.channels == 1 {
+        for (x_out, gain) in out.iter_mut().enumerate() {
+            let gm_x = (x_out as f32 * inv_iw) * gw_f;
+            let gm_x_floor = gm_x.floor();
+            let x0 = (gm_x_floor as u32).min(gw - 1);
+            let x1 = (x0 + 1).min(gw - 1);
+            let fx = gm_x - gm_x_floor;
+            let w = shepards_weights(fx, fy);
+
+            let g_tl = lut.lookup(gainmap.data[row0_off + x0 as usize], 0);
+            let g_bl = lut.lookup(gainmap.data[row1_off + x0 as usize], 0);
+            let g_tr = lut.lookup(gainmap.data[row0_off + x1 as usize], 0);
+            let g_br = lut.lookup(gainmap.data[row1_off + x1 as usize], 0);
+            let g = dot4([g_tl, g_bl, g_tr, g_br], w);
+            *gain = [g, g, g];
+        }
+    } else {
+        for (x_out, gain) in out.iter_mut().enumerate() {
+            let gm_x = (x_out as f32 * inv_iw) * gw_f;
+            let gm_x_floor = gm_x.floor();
+            let x0 = (gm_x_floor as u32).min(gw - 1);
+            let x1 = (x0 + 1).min(gw - 1);
+            let fx = gm_x - gm_x_floor;
+            let w = shepards_weights(fx, fy);
+
+            let tl = (row0_off + x0 as usize) * 3;
+            let bl = (row1_off + x0 as usize) * 3;
+            let tr = (row0_off + x1 as usize) * 3;
+            let br = (row1_off + x1 as usize) * 3;
+            for (c, dst) in gain.iter_mut().enumerate() {
+                let corners = [
+                    lut.lookup(gainmap.data[tl + c], c),
+                    lut.lookup(gainmap.data[bl + c], c),
+                    lut.lookup(gainmap.data[tr + c], c),
+                    lut.lookup(gainmap.data[br + c], c),
+                ];
+                *dst = dot4(corners, w);
+            }
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -855,10 +1121,8 @@ mod tests {
         // Read first pixel from each
         let max_bytes = result_max.as_slice().as_strided_bytes();
         let sdr_bytes = result_sdr.as_slice().as_strided_bytes();
-        let hdr_r =
-            f32::from_le_bytes([max_bytes[0], max_bytes[1], max_bytes[2], max_bytes[3]]);
-        let sdr_r =
-            f32::from_le_bytes([sdr_bytes[0], sdr_bytes[1], sdr_bytes[2], sdr_bytes[3]]);
+        let hdr_r = f32::from_le_bytes([max_bytes[0], max_bytes[1], max_bytes[2], max_bytes[3]]);
+        let sdr_r = f32::from_le_bytes([sdr_bytes[0], sdr_bytes[1], sdr_bytes[2], sdr_bytes[3]]);
 
         // Full boost should produce significantly brighter output than no boost
         assert!(
@@ -1022,5 +1286,107 @@ mod tests {
             result,
             Err(crate::Error::Stopped(enough::StopReason::Cancelled))
         ));
+    }
+
+    #[test]
+    fn shepards_lut_try_new_rejects_non_integer_ratio() {
+        // 5x5 image with 2x2 gainmap → no exact integer scale.
+        assert!(ShepardsLut::try_new(5, 5, 2, 2).is_none());
+        // 0-dim gainmap is rejected.
+        assert!(ShepardsLut::try_new(8, 8, 0, 2).is_none());
+        // Exact 4x scale on both axes.
+        assert!(ShepardsLut::try_new(8, 8, 2, 2).is_some());
+        // Asymmetric integer scales are still valid.
+        assert!(ShepardsLut::try_new(8, 12, 2, 3).is_some());
+    }
+
+    #[test]
+    fn shepards_lut_weights_at_sample_center_collapse_to_nearest() {
+        // Sub-pixel offset (0, 0) sits exactly on the top-left sample.
+        // C++ libultrahdr short-circuits to weights = [1, 0, 0, 0]; we mirror
+        // that so the LUT and per-pixel paths agree at sample centers.
+        let lut = ShepardsLut::new(4, 4);
+        let table = lut.pick(false, false);
+        assert_eq!(table[0], 1.0);
+        assert_eq!(table[1], 0.0);
+        assert_eq!(table[2], 0.0);
+        assert_eq!(table[3], 0.0);
+    }
+
+    #[test]
+    fn shepards_weights_normalize_to_one() {
+        // For any non-degenerate (fx, fy) the four weights must sum to 1.0
+        // (within f32 rounding). This is what makes the result independent
+        // of the underlying gain values.
+        for &fx in &[0.1f32, 0.25, 0.5, 0.75, 0.9] {
+            for &fy in &[0.1f32, 0.25, 0.5, 0.75, 0.9] {
+                let w = shepards_weights(fx, fy);
+                let total: f32 = w.iter().sum();
+                assert!(
+                    (total - 1.0).abs() < 1e-5,
+                    "weights at ({fx}, {fy}) sum to {total}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn shepards_int_lut_matches_float_path_at_sample_centers() {
+        // Walk a 4x4 image over a 2x2 gainmap (scale=2). At every output
+        // pixel that lands on a gainmap sample (offsets 0 in both axes —
+        // here that's every other pixel), both paths must agree.
+        let mut gainmap = GainMap::new(2, 2).unwrap();
+        gainmap.data = vec![10, 200, 50, 150];
+        let metadata = GainMapMetadata::default();
+        let lut = GainMapLut::new(&metadata, 1.0);
+        let shepards = ShepardsLut::try_new(4, 4, 2, 2).unwrap();
+
+        let mut row_int = vec![[0.0f32; 3]; 4];
+        let mut row_float = vec![[0.0f32; 3]; 4];
+
+        for y in [0u32, 2u32] {
+            sample_row_lut_int(&gainmap, &lut, &shepards, y, &mut row_int);
+            sample_row_lut_float(&gainmap, &lut, y, 4, 4, &mut row_float);
+            for x in [0usize, 2usize] {
+                // Sample-center pixels: weights collapse to nearest, both
+                // paths must produce identical output (no f32 drift).
+                assert_eq!(
+                    row_int[x], row_float[x],
+                    "mismatch at ({x}, {y}): int={:?} float={:?}",
+                    row_int[x], row_float[x]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn shepards_int_lut_matches_float_path_within_rounding() {
+        // Same setup, full-row comparison. Off-center pixels use precomputed
+        // vs per-pixel weights; the operations differ in associativity so
+        // bit-equality is not guaranteed, but values must agree to 1e-6.
+        let mut gainmap = GainMap::new(2, 2).unwrap();
+        gainmap.data = vec![10, 200, 50, 150];
+        let metadata = GainMapMetadata::default();
+        let lut = GainMapLut::new(&metadata, 1.0);
+        let shepards = ShepardsLut::try_new(8, 8, 2, 2).unwrap();
+
+        for y in 0..8 {
+            let mut row_int = vec![[0.0f32; 3]; 8];
+            let mut row_float = vec![[0.0f32; 3]; 8];
+            sample_row_lut_int(&gainmap, &lut, &shepards, y, &mut row_int);
+            sample_row_lut_float(&gainmap, &lut, y, 8, 8, &mut row_float);
+            for x in 0..8 {
+                for c in 0..3 {
+                    let diff = (row_int[x][c] - row_float[x][c]).abs();
+                    assert!(
+                        diff < 1e-6,
+                        "({x}, {y})[{c}]: int={} float={} diff={}",
+                        row_int[x][c],
+                        row_float[x][c],
+                        diff,
+                    );
+                }
+            }
+        }
     }
 }

--- a/ultrahdr-core/src/gainmap/compute.rs
+++ b/ultrahdr-core/src/gainmap/compute.rs
@@ -1137,8 +1137,7 @@ mod tests {
                     let dst_offset = (y as usize) * dst_stride + (x as usize) * 4;
                     for (c, &lin) in px.iter().take(3).enumerate() {
                         let srgb = linear_srgb::tf::linear_to_srgb(lin.clamp(0.0, 1.0));
-                        dst_data[dst_offset + c] =
-                            (srgb * 255.0 + 0.5).clamp(0.0, 255.0) as u8;
+                        dst_data[dst_offset + c] = (srgb * 255.0 + 0.5).clamp(0.0, 255.0) as u8;
                     }
                     dst_data[dst_offset + 3] = 255;
                 }
@@ -1169,8 +1168,7 @@ mod tests {
                     let v = (x as f32 + 1.0) / width as f32 * 2.0; // 0.125 .. 2.0
                     let offset = (y as usize) * stride + (x as usize) * 16;
                     for c in 0..3 {
-                        data[offset + c * 4..offset + c * 4 + 4]
-                            .copy_from_slice(&v.to_le_bytes());
+                        data[offset + c * 4..offset + c * 4 + 4].copy_from_slice(&v.to_le_bytes());
                     }
                     data[offset + 12..offset + 16].copy_from_slice(&1.0_f32.to_le_bytes());
                 }

--- a/ultrahdr-core/src/gainmap/splitter.rs
+++ b/ultrahdr-core/src/gainmap/splitter.rs
@@ -7,7 +7,7 @@
 //! HDR_i = (SDR_i + base_offset_i) · 2^g − alternate_offset_i      (per channel i)
 //! ```
 //!
-//! Mirrors the gain form consumed by [`super::apply`]. Round-trip is exact
+//! Mirrors the gain form consumed by [`crate::gainmap::apply`]. Round-trip is exact
 //! within float precision when (a) the curve is strictly monotonic, (b) the
 //! observed gain fits in `[min_log2, max_log2]`, and (c) the SDR rescale
 //! stays in `[0, 1]`. Out-of-gamut highlights clamp on the SDR side and

--- a/ultrahdr-core/src/gainmap/streaming.rs
+++ b/ultrahdr-core/src/gainmap/streaming.rs
@@ -103,6 +103,7 @@ pub struct RowDecoder {
     width: u32,
     height: u32,
     lut: super::apply::GainMapLut,
+    shepards: Option<super::apply::ShepardsLut>,
     base_offset: [f32; 3],
     alternate_offset: [f32; 3],
     current_row: u32,
@@ -133,6 +134,8 @@ impl RowDecoder {
     ) -> Result<Self> {
         let weight = super::apply::calculate_weight(display_boost, &metadata);
         let lut = super::apply::GainMapLut::new(&metadata, weight);
+        let shepards =
+            super::apply::ShepardsLut::try_new(width, height, gainmap.width, gainmap.height);
         let base_offset = [
             metadata.channels[0].base_offset as f32,
             metadata.channels[1].base_offset as f32,
@@ -150,6 +153,7 @@ impl RowDecoder {
             width,
             height,
             lut,
+            shepards,
             base_offset,
             alternate_offset,
             current_row: 0,
@@ -210,10 +214,11 @@ impl RowDecoder {
                 ];
             }
 
-            // Sample per-channel gains for this row (bilinear + LUT).
+            // Sample per-channel gains for this row (Shepard's IDW + LUT).
             super::apply::sample_gainmap_row_lut(
                 &self.gainmap,
                 &self.lut,
+                self.shepards.as_ref(),
                 y,
                 self.width,
                 self.height,
@@ -1306,7 +1311,8 @@ mod tests {
             false,
         );
 
-        let mut decoder = RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
+        let mut decoder =
+            RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
 
         // Linear f32 RGB input (mid-gray = 0.18)
         let sdr_linear = vec![0.18f32; 4 * 3]; // One row, 4 pixels, RGB
@@ -1395,7 +1401,8 @@ mod tests {
         let gainmap = test_gainmap(128);
         let metadata = test_metadata();
 
-        let mut decoder = RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
+        let mut decoder =
+            RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
 
         assert!(!decoder.is_complete());
         assert_eq!(decoder.rows_remaining(), 4);
@@ -1419,7 +1426,8 @@ mod tests {
         let gainmap = test_gainmap(128);
         let metadata = test_metadata();
 
-        let mut decoder = RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
+        let mut decoder =
+            RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
 
         let sdr_row = vec![0.18f32; 4 * 3];
 
@@ -1446,7 +1454,8 @@ mod tests {
         let gainmap = test_gainmap(128);
         let metadata = test_metadata();
 
-        let mut decoder = RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
+        let mut decoder =
+            RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
 
         // Only 2 pixels worth of data (6 floats) instead of 4 pixels (12 floats)
         let short_input = vec![0.18f32; 2 * 3];
@@ -1464,7 +1473,8 @@ mod tests {
         let gainmap = test_gainmap(128);
         let metadata = test_metadata();
 
-        let mut decoder = RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
+        let mut decoder =
+            RowDecoder::new(gainmap, metadata, 4, 4, 4.0, ColorPrimaries::Bt709).unwrap();
 
         let sdr_row = vec![0.18f32; 4 * 3];
         for _ in 0..4 {
@@ -1488,7 +1498,8 @@ mod tests {
 
         // SDR: 4x4, gainmap: 2x2, 1 channel
         let mut decoder =
-            StreamDecoder::new(metadata.clone(), 4, 4, 2, 2, 1, 4.0, ColorPrimaries::Bt709).unwrap();
+            StreamDecoder::new(metadata.clone(), 4, 4, 2, 2, 1, 4.0, ColorPrimaries::Bt709)
+                .unwrap();
 
         assert!(!decoder.is_complete());
         assert_eq!(decoder.sdr_rows_remaining(), 4);
@@ -1665,7 +1676,8 @@ mod tests {
         let metadata = test_metadata();
 
         // display_boost=1.0 means weight=0 → gain should be exp(0)=1.0 for all pixels
-        let mut decoder = RowDecoder::new(gainmap, metadata, 4, 4, 1.0, ColorPrimaries::Bt709).unwrap();
+        let mut decoder =
+            RowDecoder::new(gainmap, metadata, 4, 4, 1.0, ColorPrimaries::Bt709).unwrap();
 
         let sdr_val = 0.5f32;
         let sdr_row = vec![sdr_val; 4 * 3];

--- a/ultrahdr-core/src/lib.rs
+++ b/ultrahdr-core/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! JPEG-container metadata (MPF, XMP, ISO 21496-1 APP2 envelope) previously
 //! lived here in `ultrahdr_core::metadata`; it has moved to
-//! [`zenjpeg::container`] (JPEG-specific parsing) and
-//! [`zencodec::gainmap`] (codec-agnostic payload). See issue #8.
+//! `zenjpeg::container` (JPEG-specific parsing) and `zencodec::gainmap`
+//! (codec-agnostic payload). See issue #8.
 //!
 //! This crate has **no JPEG codec dependency**. For full Ultra HDR encode/decode,
 //! use the `ultrahdr` crate which provides codec integration.

--- a/ultrahdr-rs/src/encode.rs
+++ b/ultrahdr-rs/src/encode.rs
@@ -10,13 +10,9 @@ use ultrahdr_core::{PixelFormat, TransferFunction, Unstoppable};
 use ultrahdr_core::{GainMap, PixelBuffer, clone_pixel_buffer, pixel_buffer_from_vec};
 
 use zencodec::Iso21496Format;
-use zencodec::gainmap::{
-    ISO_21496_1_PRIMARY_APP2_BODY, serialize_iso21496_fmt,
-};
+use zencodec::gainmap::{ISO_21496_1_PRIMARY_APP2_BODY, serialize_iso21496_fmt};
 use zenjpeg::container::mpf::create_mpf_header;
-use zenjpeg::container::xmp::{
-    create_xmp_app1_marker, generate_gainmap_xmp, generate_primary_xmp,
-};
+use zenjpeg::container::xmp::{create_xmp_app1_marker, generate_gainmap_xmp, generate_primary_xmp};
 
 use crate::jpeg::{
     JpegSegment, create_icc_markers, get_icc_profile_for_gamut, insert_segment_after_soi,

--- a/ultrahdr-rs/tests/decode_basic.rs
+++ b/ultrahdr-rs/tests/decode_basic.rs
@@ -44,7 +44,11 @@ fn test_decode_sdr() {
 
     assert!(sdr.width() > 0, "Width should be positive");
     assert!(sdr.height() > 0, "Height should be positive");
-    assert_eq!(sdr.descriptor().pixel_format(), PixelFormat::Rgba8, "SDR should be RGBA8");
+    assert_eq!(
+        sdr.descriptor().pixel_format(),
+        PixelFormat::Rgba8,
+        "SDR should be RGBA8"
+    );
     assert_eq!(
         sdr.as_slice().as_strided_bytes().len(),
         (sdr.width() * sdr.height() * 4) as usize,
@@ -131,7 +135,11 @@ fn test_dimensions_consistent() {
     assert_eq!(w, sdr.width(), "dimensions() width should match SDR");
     assert_eq!(h, sdr.height(), "dimensions() height should match SDR");
     assert_eq!(sdr.width(), hdr.width(), "SDR and HDR width should match");
-    assert_eq!(sdr.height(), hdr.height(), "SDR and HDR height should match");
+    assert_eq!(
+        sdr.height(),
+        hdr.height(),
+        "SDR and HDR height should match"
+    );
 }
 
 /// Test raw gain map JPEG is accessible.

--- a/ultrahdr-rs/tests/encoder_production.rs
+++ b/ultrahdr-rs/tests/encoder_production.rs
@@ -132,7 +132,11 @@ fn test_encode_ultrahdr_gamuts() {
     let gainmap = stub_jpeg();
     let metadata = test_metadata();
 
-    for gamut in [ColorPrimaries::Bt709, ColorPrimaries::DisplayP3, ColorPrimaries::Bt2020] {
+    for gamut in [
+        ColorPrimaries::Bt709,
+        ColorPrimaries::DisplayP3,
+        ColorPrimaries::Bt2020,
+    ] {
         let result = encode_ultrahdr(&base, &gainmap, &metadata, gamut);
         assert!(
             result.is_ok(),

--- a/ultrahdr-rs/tests/libultrahdr_parity.rs
+++ b/ultrahdr-rs/tests/libultrahdr_parity.rs
@@ -92,7 +92,10 @@ fn decode_pixel_samples() {
             path.display()
         );
         let meta = dec.metadata().unwrap_or_else(|| {
-            panic!("{}: metadata() is None on a Pixel-produced UltraHDR file", path.display())
+            panic!(
+                "{}: metadata() is None on a Pixel-produced UltraHDR file",
+                path.display()
+            )
         });
         assert!(
             meta.alternate_hdr_headroom > 0.0,
@@ -191,7 +194,10 @@ fn awesome_gain_maps_variety() {
         }
         panic!("{} awesome-gain-maps files failed to parse", failures.len());
     }
-    assert!(ok >= 10, "expected at least 10 real gain-map files, got {ok}");
+    assert!(
+        ok >= 10,
+        "expected at least 10 real gain-map files, got {ok}"
+    );
     eprintln!("awesome_gain_maps_variety: {ok} files parsed clean");
 }
 
@@ -210,7 +216,9 @@ fn icc_profile_preserved_in_libultrahdr_testdata() {
     // This is a plain JPEG (not Ultra HDR), but we should still expose its
     // ICC profile. libultrahdr writes an `iccHelper` that surfaces ICC too;
     // our Decoder::icc_profile is the counterpart.
-    let icc = dec.icc_profile().expect("ICC profile present on yuv-icc JPEG");
+    let icc = dec
+        .icc_profile()
+        .expect("ICC profile present on yuv-icc JPEG");
     assert!(
         icc.len() >= 128,
         "ICC profile too short ({} bytes); ICC v2/v4 headers are ≥ 128 B",

--- a/ultrahdr-rs/tests/libultrahdr_pixel_parity.rs
+++ b/ultrahdr-rs/tests/libultrahdr_pixel_parity.rs
@@ -140,7 +140,10 @@ fn all_pixel_samples(corpus: &Corpus) -> Vec<PathBuf> {
         })
         .collect();
     jpgs.sort();
-    assert!(!jpgs.is_empty(), "no .jpg fixtures in pixel-ultrahdr corpus");
+    assert!(
+        !jpgs.is_empty(),
+        "no .jpg fixtures in pixel-ultrahdr corpus"
+    );
     jpgs
 }
 
@@ -216,7 +219,10 @@ fn probe_metadata_matches_libultrahdr() {
 
     eprintln!(
         "probe_metadata_matches_libultrahdr: {} — all 7 fields within tolerance",
-        fixture.file_name().and_then(|s| s.to_str()).unwrap_or("<?>")
+        fixture
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("<?>")
     );
 }
 
@@ -378,10 +384,20 @@ fn sdr_decode_matches_libultrahdr() {
     // or MCU-row top (y % 16 == 0).
     eprintln!("  per-16-row max delta (first 8 + last 4):");
     for rb in 0..n_buckets.min(8) {
-        eprintln!("    rows {:>5}..{:>5}: max={}", rb * 16, rb * 16 + 15, row_max[rb]);
+        eprintln!(
+            "    rows {:>5}..{:>5}: max={}",
+            rb * 16,
+            rb * 16 + 15,
+            row_max[rb]
+        );
     }
     for rb in n_buckets.saturating_sub(4)..n_buckets {
-        eprintln!("    rows {:>5}..{:>5}: max={}", rb * 16, rb * 16 + 15, row_max[rb]);
+        eprintln!(
+            "    rows {:>5}..{:>5}: max={}",
+            rb * 16,
+            rb * 16 + 15,
+            row_max[rb]
+        );
     }
     // Column bucket max — should be roughly flat unless there's a horizontal edge issue.
     let col_max_overall = *col_max.iter().max().unwrap_or(&0);
@@ -458,7 +474,10 @@ fn hdr_decode_matches_libultrahdr() {
             .arg(&hdr_path)
             .status()
             .expect("invoke ultrahdr_app hdr decode");
-        assert!(status.success(), "ultrahdr_app hdr decode failed for {name}");
+        assert!(
+            status.success(),
+            "ultrahdr_app hdr decode failed for {name}"
+        );
 
         let lib_raw = std::fs::read(&hdr_path).expect("read libultrahdr hdr output");
         // 8 bytes/pixel (f16 RGBA). f16 lacks AnyBitPattern, so go via u16 bits.
@@ -482,7 +501,11 @@ fn hdr_decode_matches_libultrahdr() {
         );
 
         let our_floats: &[f32] = bytemuck::cast_slice(&our_hdr.as_slice().as_strided_bytes());
-        assert_eq!(our_floats.len(), lib_halfs.len(), "{name}: pixel count mismatch");
+        assert_eq!(
+            our_floats.len(),
+            lib_halfs.len(),
+            "{name}: pixel count mismatch"
+        );
 
         let mut sum_abs: f64 = 0.0;
         let mut count: u64 = 0;
@@ -510,7 +533,9 @@ fn hdr_decode_matches_libultrahdr() {
         // ~0.6% of dynamic range. f16 quantizes to ~10-bit mantissa so we
         // can't go tighter than a few ULPs at large magnitudes.
         if mae >= 0.1 {
-            failures.push(format!("{name}: MAE={mae:.6} >= 0.1 (max_abs={max_abs:.4})"));
+            failures.push(format!(
+                "{name}: MAE={mae:.6} >= 0.1 (max_abs={max_abs:.4})"
+            ));
         }
     }
 

--- a/ultrahdr-rs/tests/metadata_compliance.rs
+++ b/ultrahdr-rs/tests/metadata_compliance.rs
@@ -151,7 +151,9 @@ fn test_xmp_container_directory() {
 /// Test ISO metadata serialization round-trip.
 #[test]
 fn test_iso21496_roundtrip() {
-    use zencodec::gainmap::{parse_iso21496_fmt as parse_iso21496, serialize_iso21496_fmt as serialize_iso21496};
+    use zencodec::gainmap::{
+        parse_iso21496_fmt as parse_iso21496, serialize_iso21496_fmt as serialize_iso21496,
+    };
 
     let original = create_test_metadata(4.0);
 
@@ -241,7 +243,9 @@ fn test_iso21496_flags() {
 /// Test ISO metadata handles extreme values.
 #[test]
 fn test_iso21496_extreme_values() {
-    use zencodec::gainmap::{parse_iso21496_fmt as parse_iso21496, serialize_iso21496_fmt as serialize_iso21496};
+    use zencodec::gainmap::{
+        parse_iso21496_fmt as parse_iso21496, serialize_iso21496_fmt as serialize_iso21496,
+    };
 
     let mut metadata = GainMapMetadata::default();
     for ch in &mut metadata.channels {

--- a/ultrahdr-rs/tests/roundtrip.rs
+++ b/ultrahdr-rs/tests/roundtrip.rs
@@ -56,9 +56,12 @@ fn test_roundtrip_sdr_quality() {
     for (i, chunk) in sdr_out.as_slice().as_strided_bytes().chunks(4).enumerate() {
         let orig_offset = i * 4;
         if orig_offset + 2 < sdr.as_slice().as_strided_bytes().len() {
-            let diff_r = (chunk[0] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset] as i16).abs();
-            let diff_g = (chunk[1] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset + 1] as i16).abs();
-            let diff_b = (chunk[2] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset + 2] as i16).abs();
+            let diff_r =
+                (chunk[0] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset] as i16).abs();
+            let diff_g =
+                (chunk[1] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset + 1] as i16).abs();
+            let diff_b =
+                (chunk[2] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset + 2] as i16).abs();
             max_diff = max_diff.max(diff_r).max(diff_g).max(diff_b);
         }
     }
@@ -95,11 +98,14 @@ fn test_roundtrip_gradient() {
     for (i, chunk) in sdr_out.as_slice().as_strided_bytes().chunks(4).enumerate() {
         let orig_offset = i * 4;
         if orig_offset + 2 < sdr.as_slice().as_strided_bytes().len() {
-            total_error += (chunk[0] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset] as i16).unsigned_abs() as u64;
-            total_error +=
-                (chunk[1] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset + 1] as i16).unsigned_abs() as u64;
-            total_error +=
-                (chunk[2] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset + 2] as i16).unsigned_abs() as u64;
+            total_error += (chunk[0] as i16 - sdr.as_slice().as_strided_bytes()[orig_offset] as i16)
+                .unsigned_abs() as u64;
+            total_error += (chunk[1] as i16
+                - sdr.as_slice().as_strided_bytes()[orig_offset + 1] as i16)
+                .unsigned_abs() as u64;
+            total_error += (chunk[2] as i16
+                - sdr.as_slice().as_strided_bytes()[orig_offset + 2] as i16)
+                .unsigned_abs() as u64;
         }
     }
 

--- a/ultrahdr-rs/tests/wasm.rs
+++ b/ultrahdr-rs/tests/wasm.rs
@@ -36,7 +36,10 @@ fn test_wasm_decode_sdr() {
     let sdr = decoder.decode_sdr().expect("decode SDR");
     assert!(sdr.width() > 0, "width should be positive");
     assert!(sdr.height() > 0, "height should be positive");
-    assert!(!sdr.as_slice().as_strided_bytes().is_empty(), "data should not be empty");
+    assert!(
+        !sdr.as_slice().as_strided_bytes().is_empty(),
+        "data should not be empty"
+    );
 }
 
 #[wasm_bindgen_test]
@@ -55,7 +58,10 @@ fn test_wasm_decode_hdr() {
     let hdr = decoder.decode_hdr(4.0).expect("decode HDR");
     assert!(hdr.width() > 0, "HDR width should be positive");
     assert!(hdr.height() > 0, "HDR height should be positive");
-    assert!(!hdr.as_slice().as_strided_bytes().is_empty(), "HDR data should not be empty");
+    assert!(
+        !hdr.as_slice().as_strided_bytes().is_empty(),
+        "HDR data should not be empty"
+    );
 }
 
 #[wasm_bindgen_test]

--- a/ultrahdr-rs/tests/zenjpeg_integration.rs
+++ b/ultrahdr-rs/tests/zenjpeg_integration.rs
@@ -5,11 +5,12 @@
 
 use ultrahdr_rs::{
     ColorPrimaries, GainMap, PixelBuffer, PixelFormat, TransferFunction,
-    Unstoppable as CoreUnstoppable, pixel_buffer_from_vec,
+    Unstoppable as CoreUnstoppable,
     gainmap::{
         apply::{HdrOutputFormat, apply_gainmap},
         compute::{GainMapConfig, compute_gainmap},
     },
+    pixel_buffer_from_vec,
 };
 
 // Re-export zenjpeg types for tests
@@ -722,7 +723,10 @@ fn test_readme_workflow_encode_decode() {
     // Verify HDR reconstruction
     assert_eq!(hdr_reconstructed.width(), width);
     assert_eq!(hdr_reconstructed.height(), height);
-    assert_eq!(hdr_reconstructed.descriptor().pixel_format(), PixelFormat::RgbaF32);
+    assert_eq!(
+        hdr_reconstructed.descriptor().pixel_format(),
+        PixelFormat::RgbaF32
+    );
 
     // Verify HDR values exceed SDR range (> 1.0)
     let hdr_data = &hdr_reconstructed.as_slice().as_strided_bytes();


### PR DESCRIPTION
## Summary

Swap bilinear upsample for Shepard's IDW in `sample_gainmap_lut`, matching libultrahdr's CPU reference (`sampleMap` in `gainmapmath.cpp:877-924`). libultrahdr's GPU path uses bilinear (hardware texture sampler); the ISO 21496-1 spec doesn't mandate either filter. Our implementation was bilinear, which drifted from `ultrahdr_app`'s CPU output on high-frequency gain at cell boundaries.

## Numbers

Pixel-parity test against `ultrahdr_app` built from libultrahdr main, full display boost, 3 corpus fixtures:

| Fixture | Bilinear MAE | Shepard's MAE | Δ |
|---|---:|---:|---:|
| `_01.jpg` | 0.00428 | **0.00388** | −9% |
| `_02.jpg` | 0.00238 | **0.00208** | −13% |
| `_05.jpg` | 0.00143 | **0.00133** | −7% |

max_abs per-pixel outliers also drop (from 1–5 units to 0.3–1.2). Residual error is at f16-ULP magnitude since libultrahdr outputs f16 RGBA and we compute in f32 before the conversion.

## Implementation

New `shepards_4pt(v00, v10, v01, v11, fx, fy)` helper replaces the prior `bilinear` one in `sample_gainmap_lut`. 4 reciprocal square roots + 4 multiplies + 3 adds + 1 divide per sample. Exact-corner inputs (`fx` or `fy` at 0.0 or 1.0) short-circuit to the matching corner sample so it agrees with nearest-neighbor at sample centers.

Matches the non-LUT branch of libultrahdr's `sampleMap` pixel-for-pixel within f32 rounding.

## Follow-ups

- [ ] **LUT-precomputed Shepard's for integer scales** — libultrahdr has this variant that amortizes the sqrt/divide to `scale²` total (16 precomputed weight sets for scale=4 vs 8M per-pixel sqrts on a 4K image). Pure perf; parity is already achieved without it. Stage as a separate PR.
- [ ] **Benchmark the cost.** Shepard's adds 4 sqrts/divides per pixel vs bilinear's 4 multiplies. For 4K HDR decode that's ~20-40ms extra on the decode path. Measure and decide if the LUT optimization is worth pursuing.

## Test plan

- [x] `cargo test --workspace` — all 300+ tests green
- [x] `ULTRAHDR_APP=… cargo test --features __pixel-parity --test libultrahdr_pixel_parity` — 4/4 pass, MAE improves on all 3 fixtures