### PR TITLE
chore(ultrahdr-core): #[doc(hidden)] deprecated public surface ahead of 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,42 @@ own section below.
     discourage silent large-pixel copies).
   - `RawImageRef<'_>` / `RawImageRefMut<'_>` → `PixelSlice<'_>` /
     `PixelSliceMut<'_>`.
+- **Deletions queued** (marked `#[doc(hidden)]` in the current release,
+  dropped in 0.5.0). None of these are reached from ultrahdr-rs's
+  documented decode/encode paths. If you use any of these, switch now.
+  - `color::transfer::{SrgbEotfLut, PqEotfLut, HlgOetfInvLut}` — dead LUT
+    types. Callers needing per-byte linearization should call
+    `linear_srgb::tf::*` directly (no setup cost).
+  - `color::transfer::{apply_oetf, apply_eotf}` — generic dispatchers
+    with silent sRGB fallback on unknown transfers (footgun).
+  - `color::transfer::{pq_to_nits, nits_to_pq}` — trivial `* 10000` /
+    `/ 10000`; inline at call sites.
+  - `color::transfer::hlg_oetf` (forward direction). The only useful
+    direction is `hlg_oetf_inv` (decode); use `linear_srgb::tf::linear_to_hlg`
+    directly if you need the forward path.
+  - `color::streaming_tonemap::*` — pass-through re-export of
+    `zentone::experimental::{StreamingTonemapConfig, StreamingTonemapper}`.
+    Import directly from `zentone` instead.
+  - `color::tonemap` zentone re-exports: `Bt2408Tonemapper`, `EetfSpace`,
+    `CompiledFilmicSpline`, `FilmicSplineConfig`, `AgxLook`, `ToneMap`,
+    `ToneMapCurve`, and the named curve functions (`aces_ap1`,
+    `agx_tonemap`, `bt2390_tonemap`, `bt2390_tonemap_ext`,
+    `filmic_narkowicz`, `hable_filmic`, `reinhard_extended`,
+    `reinhard_jodie`, `reinhard_simple`). Pure pass-throughs; import
+    from `zentone` / `zentone::curves` directly.
+  - `gainmap::streaming::*` — `RowEncoder`, `StreamEncoder`,
+    `RowDecoder`, `StreamDecoder` (+ their configs and stats types).
+    The per-row kernels these wrap (`sample_gainmap_row_lut`,
+    `apply_gain_row_presampled`) stay; the state-machine/ring-buffer
+    glue is Ultra-HDR-specific and doesn't generalize (no imageflow or
+    zenjpeg consumer for it).
+  - `gainmap::splitter::*` — `LumaGainMapSplitter`, `SplitConfig`,
+    `SplitStats`, `LumaToneMap`, `LumaFn`, `HableFilmic`. Only used by
+    `compute_gainmap_tonemap` (also deprecated).
+  - `gainmap::compute::compute_gainmap_tonemap` — HDR-only compute with
+    explicit tone-curve injection. Niche; callers wanting this pattern
+    should stage a `zentone` curve, apply it to produce SDR, then call
+    `compute_gainmap(hdr, sdr, …)` with the SDR they produced.
 
 #### Added
 - Re-export `PixelBuffer`, `PixelSlice`, `PixelSliceMut` at the crate root.

--- a/ultrahdr-core/src/color/mod.rs
+++ b/ultrahdr-core/src/color/mod.rs
@@ -23,16 +23,14 @@ pub use transfer::*;
 #[cfg(feature = "zentone")]
 pub use tonemap::*;
 
-/// Streaming (row-based, bounded-memory) HDR→SDR tonemapper.
-///
-/// Re-exported from `zentone::experimental::streaming` when the `zentone`
-/// feature is enabled (default). Pull-based API:
-/// [`push_row`](StreamingTonemapper::push_row), [`finish`](StreamingTonemapper::finish),
-/// [`pull_row`](StreamingTonemapper::pull_row). Channel count (3 or 4) is
-/// passed to [`StreamingTonemapper::new`], not stored in the config.
+/// **Deprecated** — slated for removal in 0.5.0. Pass-through re-export
+/// of `zentone::experimental::{StreamingTonemapConfig, StreamingTonemapper}`;
+/// no ultrahdr-core-specific logic here. Import directly from `zentone`.
 #[cfg(feature = "zentone")]
+#[doc(hidden)]
 pub mod streaming_tonemap {
     pub use zentone::experimental::{StreamingTonemapConfig, StreamingTonemapper};
 }
 #[cfg(feature = "zentone")]
+#[doc(hidden)]
 pub use streaming_tonemap::*;

--- a/ultrahdr-core/src/color/tonemap.rs
+++ b/ultrahdr-core/src/color/tonemap.rs
@@ -81,18 +81,30 @@ impl Default for ToneMapConfig {
 // [`crate::LumaToneMap`] implementation) and none of these symbols exist.
 
 /// Re-exported from [`zentone`]. BT.2408 PQ-domain tonemapper.
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. This is a
+/// pass-through re-export; import directly from the `zentone` crate.
 #[cfg(feature = "zentone")]
+#[doc(hidden)]
 pub use zentone::{Bt2408Tonemapper, EetfSpace};
 
 /// Standard tone curves re-exported from [`zentone::curves`].
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. These are
+/// pass-through re-exports; import directly from `zentone::curves`.
 #[cfg(feature = "zentone")]
+#[doc(hidden)]
 pub use zentone::curves::{
     aces_ap1, agx_tonemap, bt2390_tonemap, bt2390_tonemap_ext, filmic_narkowicz, hable_filmic,
     reinhard_extended, reinhard_jodie, reinhard_simple,
 };
 
 /// Re-exported from [`zentone`]. Filmic spline tonemapper.
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. Pass-through
+/// re-export; import directly from `zentone`.
 #[cfg(feature = "zentone")]
+#[doc(hidden)]
 pub use zentone::{CompiledFilmicSpline, FilmicSplineConfig};
 
 // ============================================================================
@@ -251,7 +263,11 @@ impl ProfileToneCurve {
 // ============================================================================
 
 /// Re-exported from [`zentone`]. Unified tone curve enum + dispatch trait.
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. Pass-through
+/// re-export; import directly from `zentone`.
 #[cfg(feature = "zentone")]
+#[doc(hidden)]
 pub use zentone::{AgxLook, ToneMap, ToneMapCurve};
 
 // ============================================================================

--- a/ultrahdr-core/src/color/transfer.rs
+++ b/ultrahdr-core/src/color/transfer.rs
@@ -64,12 +64,20 @@ pub fn pq_eotf(encoded: f32) -> f32 {
 }
 
 /// Convert PQ-normalized linear to absolute nits.
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. Trivial
+/// `pq_linear * 10000.0`; inline at call sites.
+#[doc(hidden)]
 #[inline]
 pub fn pq_to_nits(pq_linear: f32) -> f32 {
     pq_linear * 10000.0
 }
 
 /// Convert absolute nits to PQ-normalized linear.
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. Trivial
+/// `nits / 10000.0`; inline at call sites.
+#[doc(hidden)]
 #[inline]
 pub fn nits_to_pq(nits: f32) -> f32 {
     nits / 10000.0
@@ -83,6 +91,11 @@ pub fn nits_to_pq(nits: f32) -> f32 {
 ///
 /// Input is scene-referred linear light (not display-referred).
 /// Delegates to `linear-srgb` (fast log2 approximation, ~5e-6 max error).
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. No internal
+/// caller; decode direction is [`hlg_oetf_inv`]. If you need the forward
+/// direction, import `linear_srgb::tf::linear_to_hlg` directly.
+#[doc(hidden)]
 #[inline]
 pub fn hlg_oetf(linear: f32) -> f32 {
     linear_srgb::tf::linear_to_hlg(linear)
@@ -150,6 +163,11 @@ pub fn hlg_eotf(encoded: f32, display_peak_nits: f32) -> f32 {
 ///
 /// Transfer functions outside ultrahdr's handled set (Srgb, Linear, Pq,
 /// Hlg) — for example BT.709, Gamma 2.2 — fall through to sRGB.
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. The silent
+/// sRGB fallback on unknown transfers is a correctness footgun; callers
+/// should dispatch explicitly on [`TransferFunction`].
+#[doc(hidden)]
 #[inline]
 pub fn apply_oetf(linear: f32, transfer: TransferFunction) -> f32 {
     match transfer {
@@ -165,6 +183,10 @@ pub fn apply_oetf(linear: f32, transfer: TransferFunction) -> f32 {
 ///
 /// For HLG, assumes a 1000 nit display and returns normalized linear `[0,1]`.
 /// Unhandled variants fall through to sRGB (see [`apply_oetf`]).
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. Same silent
+/// sRGB fallback footgun as [`apply_oetf`].
+#[doc(hidden)]
 #[inline]
 pub fn apply_eotf(encoded: f32, transfer: TransferFunction) -> f32 {
     match transfer {
@@ -184,6 +206,12 @@ pub fn apply_eotf(encoded: f32, transfer: TransferFunction) -> f32 {
 // ============================================================================
 
 /// Precomputed LUT for sRGB EOTF (8-bit input).
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. Not used
+/// internally; no known external callers. Callers needing per-byte
+/// linearization should call `linear_srgb::tf::srgb_to_linear` directly
+/// (which already uses a rational-polynomial fast path with zero setup cost).
+#[doc(hidden)]
 pub struct SrgbEotfLut {
     table: [f32; 256],
 }
@@ -212,6 +240,10 @@ impl Default for SrgbEotfLut {
 }
 
 /// Precomputed LUT for PQ EOTF (10-bit input, 1024 entries).
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. Not used
+/// internally; no known external callers.
+#[doc(hidden)]
 pub struct PqEotfLut {
     table: Box<[f32; 1024]>,
 }
@@ -240,6 +272,10 @@ impl Default for PqEotfLut {
 }
 
 /// Precomputed LUT for HLG inverse OETF (10-bit input).
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. Not used
+/// internally; no known external callers.
+#[doc(hidden)]
 pub struct HlgOetfInvLut {
     table: Box<[f32; 1024]>,
 }

--- a/ultrahdr-core/src/gainmap/compute.rs
+++ b/ultrahdr-core/src/gainmap/compute.rs
@@ -432,6 +432,12 @@ fn write_rgba32f_row(out_data: &mut [u8], stride: usize, width: u32, y: u32, row
 ///
 /// Multi-channel gain maps are not supported — returns
 /// `Err(EncodeError)` if `config.multi_channel` is `true`.
+///
+/// **Deprecated API surface** — slated for removal in 0.5.0. The
+/// splitter-based path ships with the [`HableFilmic`] default curve;
+/// callers with explicit tone-curve control needs should stage a zentone
+/// curve + call [`compute_gainmap`] with their own tonemapped SDR.
+#[doc(hidden)]
 pub fn compute_gainmap_tonemap<T: LumaToneMap>(
     hdr: PixelSlice<'_>,
     curve: &T,

--- a/ultrahdr-core/src/gainmap/mod.rs
+++ b/ultrahdr-core/src/gainmap/mod.rs
@@ -6,13 +6,25 @@
 pub mod apply;
 pub mod apply_simd;
 pub mod compute;
+/// **Deprecated** — slated for removal in 0.5.0. The splitter trait +
+/// Hable curve are used only by [`compute::compute_gainmap_tonemap`]
+/// (also deprecated). Hidden from docs; types are still accessible for
+/// internal and any stray external use until 0.5.0.
+#[doc(hidden)]
 pub mod splitter;
+/// **Deprecated** — slated for removal in 0.5.0. See the individual
+/// struct docs for rationale. The per-row kernels in
+/// [`apply`](self::apply) + [`apply_simd`](self::apply_simd) are the
+/// reusable surface.
+#[doc(hidden)]
 pub mod streaming;
 
 pub use apply::*;
 pub use apply_simd::*;
 pub use compute::*;
+#[doc(hidden)]
 pub use splitter::{
     HableFilmic, LumaFn, LumaGainMapSplitter, LumaToneMap, SplitConfig, SplitStats,
 };
+#[doc(hidden)]
 pub use streaming::*;

--- a/ultrahdr-core/src/gainmap/splitter.rs
+++ b/ultrahdr-core/src/gainmap/splitter.rs
@@ -56,6 +56,7 @@ use crate::types::ColorPrimaries;
 ///
 /// Implementors must be **strictly monotonic** on the operating range and
 /// produce output in `[0, 1]`. To wrap an ad-hoc closure, use [`LumaFn`].
+#[doc(hidden)]
 pub trait LumaToneMap {
     /// Map a single linear-light luminance sample.
     fn map_luma(&self, y_hdr: f32) -> f32;
@@ -63,6 +64,7 @@ pub trait LumaToneMap {
 
 /// Adapt a closure as a [`LumaToneMap`]. Caller is responsible for
 /// monotonicity and `[0, 1]` output range.
+#[doc(hidden)]
 pub struct LumaFn<F: Fn(f32) -> f32>(pub F);
 
 impl<F: Fn(f32) -> f32> LumaToneMap for LumaFn<F> {
@@ -97,6 +99,7 @@ impl<T: LumaToneMap + ?Sized> LumaToneMap for Box<T> {
 /// metadata. For content-aware curves, enable the `zentone` feature and
 /// use BT.2408/BT.2446 or the filmic spline instead.
 #[derive(Debug, Clone, Copy, Default)]
+#[doc(hidden)]
 pub struct HableFilmic;
 
 impl HableFilmic {
@@ -187,6 +190,7 @@ mod zentone_adapters {
 /// `max` should come from [`SplitStats::observed_min_log2`] /
 /// [`SplitStats::observed_max_log2`] after a pass over the image.
 #[derive(Debug, Clone, Copy)]
+#[doc(hidden)]
 pub struct SplitConfig {
     /// RGB → Y weights. Must match the input primaries.
     pub luma_weights: [f32; 3],
@@ -244,6 +248,7 @@ impl Default for SplitConfig {
 /// [`zencodec::GainMapParams`] metadata or use to tighten `min_log2` /
 /// `max_log2` on a second pass.
 #[derive(Debug, Clone, Copy)]
+#[doc(hidden)]
 pub struct SplitStats {
     /// Smallest pre-clamp `log2` gain seen. Initialize to `f32::INFINITY`.
     pub observed_min_log2: f32,
@@ -268,6 +273,7 @@ impl Default for SplitStats {
 ///
 /// Stateless after construction. Safe to share across threads (`Sync`)
 /// when the inner curve is `Sync`.
+#[doc(hidden)]
 pub struct LumaGainMapSplitter<T: LumaToneMap> {
     curve: T,
     cfg: SplitConfig,

--- a/ultrahdr-core/src/gainmap/streaming.rs
+++ b/ultrahdr-core/src/gainmap/streaming.rs
@@ -90,6 +90,13 @@ use super::compute::GainMapConfig;
 ///
 /// - Gainmap: `gm_width × gm_height × channels` bytes
 /// - Per batch: `width × batch_rows × 16` bytes (RGBA f32)
+/// **Deprecated API surface** — slated for removal in 0.5.0.
+///
+/// No known external callers. The per-row kernels this type wraps
+/// (`sample_gainmap_row_lut`, `apply_gain_row_presampled`) are the
+/// reusable surface; this state machine is Ultra-HDR-specific glue
+/// that doesn't compose cleanly with zenjpeg's streaming model.
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct RowDecoder {
     gainmap: GainMap,
@@ -284,6 +291,9 @@ impl RowDecoder {
 /// # Memory Model
 ///
 /// - Gainmap ring buffer: 16 rows × `gm_width × channels` bytes
+/// **Deprecated API surface** — slated for removal in 0.5.0. See
+/// [`RowDecoder`] for rationale.
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct StreamDecoder {
     sdr_width: u32,
@@ -572,6 +582,9 @@ impl StreamDecoder {
 ///
 /// - HDR: Linear f32 RGB, 3 floats per pixel, values typically `[0, ~10]`
 /// - SDR: Linear f32 RGB, 3 floats per pixel, values in `[0, 1]`
+/// **Deprecated API surface** — slated for removal in 0.5.0. See
+/// [`RowDecoder`] for rationale.
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct RowEncoder {
     config: GainMapConfig,
@@ -853,6 +866,9 @@ impl RowEncoder {
 ///
 /// - HDR: Linear f32 RGB, 3 floats per pixel
 /// - SDR: Linear f32 RGB, 3 floats per pixel
+/// **Deprecated API surface** — slated for removal in 0.5.0. See
+/// [`RowDecoder`] for rationale.
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct StreamEncoder {
     config: GainMapConfig,


### PR DESCRIPTION
## Summary

Applies `#[doc(hidden)]` to ~30 public symbols that no documented ultrahdr-rs decode/encode path reaches, pre-staging deletion for 0.5.0. Non-breaking today — symbols are still accessible to any caller who already imports them by name, just not listed in rustdoc. Each hidden item's docstring names what to use instead.

## Audit: does any of this move to zenjpeg?

I checked specifically. Nothing in `gainmap/streaming.rs` transplants:

- **What zenjpeg would need** for a future streaming HDR decode mode: the per-row kernels `sample_gainmap_row_lut` and `apply_gain_row_presampled`. Those already live in `gainmap/apply.rs` + `gainmap/apply_simd.rs` at crate-internal scope and aren't part of this deprecation.
- **What streaming.rs actually contains**: ring buffers + row-sync state machines for "decode two JPEGs in parallel → feed gain-apply row-by-row." That's Ultra-HDR-specific composition glue; zenjpeg wouldn't express it the same way if it did streaming HDR decode internally (its own streaming machinery would drive the per-row kernel imports directly).

Same for `splitter.rs` + `compute_gainmap_tonemap` — only one internal caller each, no external need.

## Hidden in this PR

**color/transfer.rs dead code**
- `SrgbEotfLut`, `PqEotfLut`, `HlgOetfInvLut` — LUT types nobody constructs
- `apply_oetf`, `apply_eotf` — generic dispatchers with silent sRGB fallback (footgun)
- `pq_to_nits`, `nits_to_pq` — trivial `* 10000` / `/ 10000`
- `hlg_oetf` (the forward direction) — only `hlg_oetf_inv` is used

**color/tonemap.rs zentone pass-through re-exports**
- `Bt2408Tonemapper`, `EetfSpace`, `CompiledFilmicSpline`, `FilmicSplineConfig`
- `AgxLook`, `ToneMap`, `ToneMapCurve`
- The 9 named curve functions (`aces_ap1`, `agx_tonemap`, `bt2390_tonemap`, `bt2390_tonemap_ext`, `filmic_narkowicz`, `hable_filmic`, `reinhard_extended`, `reinhard_jodie`, `reinhard_simple`)

**color/mod.rs**
- `streaming_tonemap` module (pass-through of `zentone::experimental`)

**gainmap/streaming.rs**
- `RowDecoder`, `StreamDecoder`, `RowEncoder`, `StreamEncoder` + all configs/stats types

**gainmap/splitter.rs**
- `LumaGainMapSplitter`, `SplitConfig`, `SplitStats`, `LumaToneMap`, `LumaFn`, `HableFilmic`

**gainmap/compute.rs**
- `compute_gainmap_tonemap`

## CHANGELOG

All hidden symbols enumerated under `## ultrahdr-core` → `### [Unreleased]` → `#### QUEUED BREAKING CHANGES` with their replacement-guidance text. The 0.5.0 deletion PR should be mechanical — grep `#[doc(hidden)]`, delete the item, delete the tests, done.

## Test plan

- [x] `cargo build --workspace` — no warnings, no errors
- [x] `cargo test --workspace` — all 300+ tests green (all internal callers of the hidden items still compile and pass; the hide attribute is purely a docs-gen concern)

## What stays public (operational surface)

Reference for what the supported API actually is after this:

- `Error`, `Result`; `ColorPrimaries`, `TransferFunction`, `PixelFormat`, `PixelBuffer`, `PixelSlice`, `PixelSliceMut` (zenpixels re-exports)
- `GainMap`, `GainMapMetadata`, `GainMapChannel`, `GainMapEncodingFormat`, `Iso21496Format`, `Fraction`, `UnsignedFraction`
- `validate_gainmap_metadata`, `parse_iso21496_fmt`, `serialize_iso21496_fmt`
- `HdrOutputFormat`, `apply_gainmap`, `apply_gainmap_slice`
- `GainMapConfig`, `compute_gainmap`, `compute_gainmap_slice`
- `new_pixel_buffer`, `pixel_buffer_from_vec`, `clone_pixel_buffer`
- `luminance`, `limits` modules
- `color::gamut::{convert_gamut, soft_clip_gamut, rgb_to_luminance, luma_coefficients, BT709_LUMA, P3_LUMA, BT2100_LUMA}`
- `color::transfer` non-hidden: `srgb_oetf`, `srgb_eotf`, `pq_oetf`, `pq_eotf`, `hlg_oetf_inv`, `hlg_ootf`, `hlg_ootf_inv`, `hlg_eotf`
- `color::tonemap`: `ToneMapConfig`, `tonemap_image_to_srgb8`, `AdaptiveTonemapper` + its fit types (kept pending call on whether AdaptiveTonemapper earns its keep)
- `Stop`, `StopReason`, `Unstoppable` (enough re-exports)

## Follow-ups

- [ ] Decide fate of `AdaptiveTonemapper` + fit machinery before 0.5.0 ships — currently kept, but no operation in the imageflow-anchored user-story set reaches for it.
- [ ] 0.5.0 deletion PR (mechanical once reviews here land).