### PR TITLE
fix: bound gain-map metadata magnitudes and validate gainmap inputs

### DIFF
--- a/.github/workflows/ffi-tests.yml
+++ b/.github/workflows/ffi-tests.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Clone sibling zenjpeg (path-dep during pre-0.5 cascade coordination)
         run: git clone --depth 1 https://github.com/imazen/zenjpeg.git ../zenjpeg
 
+      - name: Clone sibling zenanalyze (transitive path-dep of zenjpeg)
+        run: git clone --depth 1 https://github.com/imazen/zenanalyze.git ../zenanalyze
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -84,6 +87,9 @@ jobs:
 
       - name: Clone sibling zenjpeg (path-dep during pre-0.5 cascade coordination)
         run: git clone --depth 1 https://github.com/imazen/zenjpeg.git ../zenjpeg
+
+      - name: Clone sibling zenanalyze (transitive path-dep of zenjpeg)
+        run: git clone --depth 1 https://github.com/imazen/zenanalyze.git ../zenanalyze
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/gainmap-interop.yml
+++ b/.github/workflows/gainmap-interop.yml
@@ -63,6 +63,7 @@ jobs:
           git clone --depth 1 https://github.com/etemesi254/zune-image.git ../zune-image
           git clone --depth 1 https://github.com/imazen/zenjpeg.git ../zenjpeg
           git clone --depth 1 https://github.com/imazen/zentone.git ../zentone
+          git clone --depth 1 https://github.com/imazen/zenanalyze.git ../zenanalyze
 
       - name: Strip workspace for standalone core tests
         run: |

--- a/ultrahdr-core/src/color/tonemap.rs
+++ b/ultrahdr-core/src/color/tonemap.rs
@@ -416,12 +416,18 @@ impl AdaptiveTonemapper {
     /// Create from gain map metadata for perfect inversion.
     ///
     /// Use this for round-trips where you want exact reproduction.
+    ///
+    /// `metadata.alternate_hdr_headroom` is clamped to
+    /// `[0.0,` [`crate::limits::MAX_HEADROOM_MAGNITUDE`]`]` before `2^h` so
+    /// hostile metadata cannot store `+inf` in `max_hdr_observed`.
     pub fn from_gainmap(metadata: &GainMapMetadata) -> Self {
+        let headroom = (metadata.alternate_hdr_headroom as f32)
+            .clamp(0.0, crate::limits::MAX_HEADROOM_MAGNITUDE as f32);
         Self {
             mode: TonemapMode::GainMapInverse(GainMapInverter {
                 metadata: metadata.clone(),
             }),
-            max_hdr_observed: 2.0f32.powf(metadata.alternate_hdr_headroom as f32),
+            max_hdr_observed: 2.0f32.powf(headroom),
             stats: FitStats::default(),
         }
     }
@@ -476,6 +482,8 @@ impl AdaptiveTonemapper {
     ) -> Result<PixelBuffer> {
         let hdr_slice = hdr.as_slice();
         crate::types::validate_ultrahdr_slice(&hdr_slice)?;
+        gainmap.validate()?;
+        crate::types::validate_gainmap_magnitude(metadata)?;
         let width = hdr_slice.width();
         let height = hdr_slice.rows();
 
@@ -496,12 +504,16 @@ impl AdaptiveTonemapper {
 
                 let gain = sample_gainmap_at(gainmap, metadata, x, y, width, height);
 
+                // `gain` is already finite and `>= 2^-30` per `decode_gain_value`'s
+                // clamp; guard against division by an effective zero anyway so a
+                // future LUT change cannot reintroduce `+inf` / `NaN` here.
+                let safe = |g: f32| if g.abs() < 1e-30 { 1.0 } else { g };
                 let sdr_linear = [
-                    (hdr_linear[0] + metadata.channels[0].alternate_offset as f32) / gain[0]
+                    (hdr_linear[0] + metadata.channels[0].alternate_offset as f32) / safe(gain[0])
                         - metadata.channels[0].base_offset as f32,
-                    (hdr_linear[1] + metadata.channels[1].alternate_offset as f32) / gain[1]
+                    (hdr_linear[1] + metadata.channels[1].alternate_offset as f32) / safe(gain[1])
                         - metadata.channels[1].base_offset as f32,
-                    (hdr_linear[2] + metadata.channels[2].alternate_offset as f32) / gain[2]
+                    (hdr_linear[2] + metadata.channels[2].alternate_offset as f32) / safe(gain[2])
                         - metadata.channels[2].base_offset as f32,
                 ];
 
@@ -819,7 +831,13 @@ impl PerChannelLut {
 /// Scale a gain map to new dimensions.
 ///
 /// Uses bilinear interpolation for smooth results.
+///
+/// Returns [`Error::InvalidDimensions`] when `gainmap` has a zero
+/// dimension or when `new_width` / `new_height` is zero.
 pub fn scale_gainmap(gainmap: &GainMap, new_width: u32, new_height: u32) -> Result<GainMap> {
+    gainmap.validate()?;
+    crate::types::validate_ultrahdr_dimensions(new_width, new_height)?;
+
     let mut output = if gainmap.channels == 1 {
         GainMap::new(new_width, new_height)?
     } else {
@@ -877,14 +895,36 @@ pub fn crop_gainmap(
     sdr_height: u32,
     crop_rect: (u32, u32, u32, u32),
 ) -> Result<GainMap> {
+    gainmap.validate()?;
+    crate::types::validate_ultrahdr_dimensions(sdr_width, sdr_height)?;
     let (crop_x, crop_y, crop_w, crop_h) = crop_rect;
+    if crop_w == 0 || crop_h == 0 {
+        return Err(Error::InvalidDimensions(crop_w, crop_h));
+    }
+    // Reject crop rects that overflow or extend past `sdr_*` bounds.
+    let crop_x_end = crop_x
+        .checked_add(crop_w)
+        .ok_or(Error::InvalidDimensions(crop_x, crop_w))?;
+    let crop_y_end = crop_y
+        .checked_add(crop_h)
+        .ok_or(Error::InvalidDimensions(crop_y, crop_h))?;
+    if crop_x_end > sdr_width || crop_y_end > sdr_height {
+        return Err(Error::InvalidDimensions(crop_x_end, crop_y_end));
+    }
 
-    // Calculate corresponding gain map region
+    // Calculate corresponding gain map region. `sdr_width` / `sdr_height` are
+    // guaranteed `> 0` by `validate_ultrahdr_dimensions`, so the f32 division
+    // is finite.
     let gm_x = (crop_x as f32 / sdr_width as f32 * gainmap.width as f32).floor() as u32;
     let gm_y = (crop_y as f32 / sdr_height as f32 * gainmap.height as f32).floor() as u32;
     let gm_w = (crop_w as f32 / sdr_width as f32 * gainmap.width as f32).ceil() as u32;
     let gm_h = (crop_h as f32 / sdr_height as f32 * gainmap.height as f32).ceil() as u32;
 
+    // Clamp gm_x/gm_y first, THEN compute the remaining-window size — the
+    // saturating sub keeps `gainmap.width - gm_x` safe even if `gm_x ==
+    // gainmap.width` (which is forced to `gainmap.width - 1` by the .min).
+    let gm_x = gm_x.min(gainmap.width.saturating_sub(1));
+    let gm_y = gm_y.min(gainmap.height.saturating_sub(1));
     let gm_w = gm_w.min(gainmap.width - gm_x).max(1);
     let gm_h = gm_h.min(gainmap.height - gm_y).max(1);
 
@@ -1195,6 +1235,11 @@ fn sample_gainmap_at(
 }
 
 /// Decode gain value from normalized [0,1] to linear multiplier.
+///
+/// Output is clamped to a finite, sane range (`2^±30`) — see
+/// [`crate::limits::MAX_LOG_GAIN_MAGNITUDE`]. This is a defense-in-depth
+/// guard for callers that skipped [`crate::types::validate_gainmap_metadata`];
+/// validated metadata can never reach the clamp boundary.
 fn decode_gain_value(normalized: f32, metadata: &GainMapMetadata, channel: usize) -> f32 {
     let gamma = metadata.channels[channel].gamma as f32;
     let linear = if gamma != 1.0 && gamma > 0.0 {
@@ -1209,7 +1254,14 @@ fn decode_gain_value(normalized: f32, metadata: &GainMapMetadata, channel: usize
     let log_max = (metadata.channels[channel].max * ln2) as f32;
     let log_gain = log_min + linear * (log_max - log_min);
 
-    log_gain.exp()
+    let gain = log_gain.exp();
+    const MAX_GAIN: f32 = 1.073_741_8e9; // 2^30
+    const MIN_GAIN: f32 = 1.0 / MAX_GAIN;
+    if !gain.is_finite() {
+        1.0
+    } else {
+        gain.clamp(MIN_GAIN, MAX_GAIN)
+    }
 }
 
 #[inline]
@@ -1688,18 +1740,14 @@ mod tests {
     #[test]
     fn test_crop_gainmap_out_of_bounds() {
         let gm = GainMap::new(4, 4).unwrap();
-        // Crop rect extends past image — should clamp (not panic)
+        // Crop rect extends past the SDR bounds (3+4 > 4). The previous
+        // behavior silently underflowed `gainmap.width - gm_x` and produced
+        // wrong-but-bounded output; security audit 2026-05-06 changed this
+        // to reject explicitly so callers know the rect is invalid.
         let result = crop_gainmap(&gm, 4, 4, (3, 3, 4, 4));
-        // The function clamps via .min(), so it should succeed with a smaller region
-        assert!(result.is_ok(), "Out-of-bounds crop should clamp, not error");
-        let cropped = result.unwrap();
         assert!(
-            cropped.width <= 4 && cropped.height <= 4,
-            "Cropped dimensions should be clamped"
-        );
-        assert!(
-            cropped.width >= 1 && cropped.height >= 1,
-            "Cropped dimensions should be at least 1x1"
+            result.is_err(),
+            "Out-of-bounds crop must be rejected, not silently clamped"
         );
     }
 

--- a/ultrahdr-core/src/gainmap/apply.rs
+++ b/ultrahdr-core/src/gainmap/apply.rs
@@ -6,9 +6,28 @@ use alloc::vec;
 use crate::color::transfer::{srgb_eotf, srgb_oetf};
 use crate::types::{
     GainMap, GainMapMetadata, PixelBuffer, PixelFormat, PixelSlice, Result, TransferFunction,
-    new_pixel_buffer,
+    new_pixel_buffer, validate_gainmap_magnitude,
 };
 use enough::Stop;
+
+/// Defense-in-depth clamp for an LUT-decoded gain multiplier.
+///
+/// Mirrors the bound in [`crate::limits::MAX_LOG_GAIN_MAGNITUDE`]:
+/// `exp(±30 * ln(2)) ≈ 2^±30 ≈ [9.3e-10, 1.07e9]`. Anything outside
+/// this range or non-finite is replaced with a neutral `1.0` so the
+/// [`HdrOutputFormat::LinearFloat`] / [`HdrOutputFormat::LinearF16`]
+/// arms cannot emit `+inf` / `NaN` pixels even if a caller skipped
+/// metadata validation.
+#[inline]
+fn clamp_gain_finite(gain: f32) -> f32 {
+    const MAX_GAIN: f32 = 1.073_741_8e9; // 2^30
+    const MIN_GAIN: f32 = 1.0 / MAX_GAIN;
+    if !gain.is_finite() {
+        1.0
+    } else {
+        gain.clamp(MIN_GAIN, MAX_GAIN)
+    }
+}
 
 /// Precomputed lookup table for gain map decoding.
 ///
@@ -49,9 +68,12 @@ impl GainMapLut {
                     normalized
                 };
 
-                // Convert from normalized to log gain, apply weight, convert to linear
+                // Convert from normalized to log gain, apply weight, convert to linear.
+                // Clamp to a finite, sane range so non-validated metadata cannot
+                // smuggle `+inf` / `NaN` into the HDR output buffer
+                // (see `clamp_gain_finite` for the bound and rationale).
                 let log_gain = log_min + linear * log_range;
-                let gain = (log_gain * weight).exp();
+                let gain = clamp_gain_finite((log_gain * weight).exp());
 
                 table[channel * 256 + i] = gain;
             }
@@ -152,6 +174,8 @@ pub fn apply_gainmap_slice(
     stop: impl Stop,
 ) -> Result<PixelBuffer> {
     crate::types::validate_ultrahdr_slice(&sdr)?;
+    gainmap.validate()?;
+    validate_gainmap_magnitude(metadata)?;
 
     let width = sdr.width();
     let height = sdr.rows();
@@ -427,9 +451,23 @@ impl ShepardsLut {
     /// Build weight tables for an arbitrary integer scale (`scale_x`, `scale_y`).
     /// Most callers should use [`Self::try_new`] which infers the scale from
     /// image and gain-map dimensions.
-    pub fn new(scale_x: u32, scale_y: u32) -> Self {
-        debug_assert!(scale_x >= 1 && scale_y >= 1);
-        let n = (scale_x * scale_y * 4) as usize;
+    ///
+    /// Returns `None` when `scale_x * scale_y` exceeds
+    /// [`crate::limits::MAX_SHEPARDS_TABLE_ENTRIES`] (the LUT would not fit
+    /// in a sane allocation) or when `checked_mul` overflows. Callers that
+    /// hit this case must fall back to the per-pixel float path.
+    ///
+    /// Also returns `None` when either scale is zero.
+    pub fn new(scale_x: u32, scale_y: u32) -> Option<Self> {
+        if scale_x == 0 || scale_y == 0 {
+            return None;
+        }
+        let entries = scale_x.checked_mul(scale_y)?;
+        if entries > crate::limits::MAX_SHEPARDS_TABLE_ENTRIES {
+            return None;
+        }
+        // `entries * 4` cannot overflow u32 once `entries <= 4096`.
+        let n = entries.checked_mul(4)? as usize;
         let mut full = vec![0.0f32; n].into_boxed_slice();
         let mut no_right = vec![0.0f32; n].into_boxed_slice();
         let mut no_bottom = vec![0.0f32; n].into_boxed_slice();
@@ -438,20 +476,22 @@ impl ShepardsLut {
         fill_shepards(&mut no_right, scale_x, scale_y, 0, 1);
         fill_shepards(&mut no_bottom, scale_x, scale_y, 1, 0);
         fill_shepards(&mut corner, scale_x, scale_y, 0, 0);
-        Self {
+        Some(Self {
             scale_x,
             scale_y,
             full,
             no_right,
             no_bottom,
             corner,
-        }
+        })
     }
 
     /// Build a LUT iff image dims are an exact integer multiple of gain-map
-    /// dims. `None` means the caller must take the per-pixel sqrt fallback.
+    /// dims AND the resulting scale fits in
+    /// [`crate::limits::MAX_SHEPARDS_TABLE_ENTRIES`]. `None` means the caller
+    /// must take the per-pixel sqrt fallback.
     pub fn try_new(img_width: u32, img_height: u32, gm_width: u32, gm_height: u32) -> Option<Self> {
-        if gm_width == 0 || gm_height == 0 {
+        if gm_width == 0 || gm_height == 0 || img_width == 0 || img_height == 0 {
             return None;
         }
         if !img_width.is_multiple_of(gm_width) || !img_height.is_multiple_of(gm_height) {
@@ -459,10 +499,7 @@ impl ShepardsLut {
         }
         let sx = img_width / gm_width;
         let sy = img_height / gm_height;
-        if sx == 0 || sy == 0 {
-            return None;
-        }
-        Some(Self::new(sx, sy))
+        Self::new(sx, sy)
     }
 
     #[inline(always)]
@@ -1418,7 +1455,7 @@ mod tests {
         // Sub-pixel offset (0, 0) sits exactly on the top-left sample.
         // C++ libultrahdr short-circuits to weights = [1, 0, 0, 0]; we mirror
         // that so the LUT and per-pixel paths agree at sample centers.
-        let lut = ShepardsLut::new(4, 4);
+        let lut = ShepardsLut::new(4, 4).expect("4x4 fits in MAX_SHEPARDS_TABLE_ENTRIES");
         let table = lut.pick(false, false);
         assert_eq!(table[0], 1.0);
         assert_eq!(table[1], 0.0);
@@ -1499,6 +1536,94 @@ mod tests {
                         diff,
                     );
                 }
+            }
+        }
+    }
+
+    // Regression: large `scale_x * scale_y` used to either wrap a u32
+    // multiplication or allocate ~16 GB (security audit 2026-05-06,
+    // finding C3). `try_new` must early-return `None` so callers fall
+    // through to the per-pixel float path.
+    #[test]
+    fn shepards_lut_try_new_caps_pathological_scale() {
+        // 65535x65535 image, 1x1 gainmap → scale 65535 each axis.
+        // 65535 * 65535 * 4 wraps u32; the cap rejects it before that.
+        assert!(ShepardsLut::try_new(65535, 65535, 1, 1).is_none());
+
+        // 32768x32768 image, 2x2 gainmap → scale 16384 each axis.
+        // 16384 * 16384 = 268M, far above MAX_SHEPARDS_TABLE_ENTRIES.
+        assert!(ShepardsLut::try_new(32768, 32768, 2, 2).is_none());
+
+        // 64x64 image, 1x1 gainmap → scale 64 each axis.
+        // 64 * 64 = 4096 — exactly at the cap, must succeed.
+        assert!(ShepardsLut::try_new(64, 64, 1, 1).is_some());
+
+        // 65x65 image, 1x1 gainmap → scale 65 each axis.
+        // 65 * 65 = 4225, just over the cap. Must reject.
+        assert!(ShepardsLut::try_new(65, 65, 1, 1).is_none());
+    }
+
+    #[test]
+    fn shepards_lut_try_new_rejects_zero_dims() {
+        assert!(ShepardsLut::try_new(0, 64, 8, 8).is_none());
+        assert!(ShepardsLut::try_new(64, 0, 8, 8).is_none());
+        assert!(ShepardsLut::try_new(64, 64, 0, 8).is_none());
+        assert!(ShepardsLut::try_new(64, 64, 8, 0).is_none());
+    }
+
+    #[test]
+    fn shepards_lut_new_rejects_zero_scale() {
+        assert!(ShepardsLut::new(0, 4).is_none());
+        assert!(ShepardsLut::new(4, 0).is_none());
+    }
+
+    // Regression: a forged GainMap with `width = 0` used to underflow
+    // `gh - 1` and panic in samplers (security audit 2026-05-06, finding
+    // C2). `apply_gainmap_slice` must reject it before any arithmetic.
+    #[test]
+    fn apply_gainmap_slice_rejects_zero_dim_gainmap() {
+        use crate::types::{ColorPrimaries, PixelBuffer, TransferFunction};
+        use enough::Unstoppable;
+
+        let desc = zenpixels::PixelDescriptor::from_pixel_format(PixelFormat::Rgba8)
+            .with_primaries(ColorPrimaries::Bt709)
+            .with_transfer(TransferFunction::Srgb);
+        let sdr = PixelBuffer::try_new(8, 8, desc).unwrap();
+        let metadata = GainMapMetadata::default();
+        let gm = GainMap {
+            width: 0,
+            height: 8,
+            channels: 1,
+            data: alloc::vec![0u8; 0],
+        };
+        let res = apply_gainmap(
+            &sdr,
+            &gm,
+            &metadata,
+            1.0,
+            HdrOutputFormat::LinearFloat,
+            Unstoppable,
+        );
+        assert!(res.is_err());
+    }
+
+    // Regression: large finite metadata used to silently produce `+inf`
+    // gain values in the LUT (security audit 2026-05-06, finding C1).
+    #[test]
+    fn gainmap_lut_clamps_large_metadata_to_finite() {
+        let mut metadata = GainMapMetadata::default();
+        // Bypass external validation — simulate a caller that did not
+        // run `validate_gainmap_magnitude`. The LUT must still produce
+        // finite values via `clamp_gain_finite`.
+        for ch in &mut metadata.channels {
+            ch.min = 1.0e30;
+            ch.max = 1.0e30;
+        }
+        let lut = GainMapLut::new(&metadata, 1.0);
+        for i in 0..256 {
+            for c in 0..3 {
+                let g = lut.lookup(i as u8, c);
+                assert!(g.is_finite(), "lut[{c}][{i}] = {g} should be finite");
             }
         }
     }

--- a/ultrahdr-core/src/gainmap/streaming.rs
+++ b/ultrahdr-core/src/gainmap/streaming.rs
@@ -58,6 +58,7 @@
 //! ```
 
 use alloc::format;
+use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -132,6 +133,9 @@ impl RowDecoder {
         display_boost: f32,
         gamut: ColorPrimaries,
     ) -> Result<Self> {
+        crate::types::validate_ultrahdr_dimensions(width, height)?;
+        gainmap.validate()?;
+        crate::types::validate_gainmap_magnitude(&metadata)?;
         let weight = super::apply::calculate_weight(display_boost, &metadata);
         let lut = super::apply::GainMapLut::new(&metadata, weight);
         let shepards =
@@ -386,6 +390,14 @@ impl StreamDecoder {
         display_boost: f32,
         gamut: ColorPrimaries,
     ) -> Result<Self> {
+        crate::types::validate_ultrahdr_dimensions(sdr_width, sdr_height)?;
+        crate::types::validate_ultrahdr_dimensions(gm_width, gm_height)?;
+        crate::types::validate_gainmap_magnitude(&metadata)?;
+        if gm_channels != 1 && gm_channels != 3 {
+            return Err(Error::InvalidPixelData(format!(
+                "gainmap channels must be 1 or 3, got {gm_channels}"
+            )));
+        }
         let weight = super::apply::calculate_weight(display_boost, &metadata);
         let lut = super::apply::GainMapLut::new(&metadata, weight);
         let base_offset = [
@@ -453,12 +465,25 @@ impl StreamDecoder {
     }
 
     /// Check if we have enough gainmap data to process the given number of SDR rows.
+    ///
+    /// `num_sdr_rows == 0` returns `true` iff there are SDR rows still to process
+    /// (the trivial "process zero rows" answer is always OK if not done).
+    /// `gm_height == 0` is rejected at construction so the `- 1` arithmetic
+    /// below cannot underflow.
     pub fn can_process(&self, num_sdr_rows: u32) -> bool {
         if self.current_sdr_row >= self.sdr_height {
             return false;
         }
+        if num_sdr_rows == 0 {
+            return true;
+        }
+        debug_assert!(self.sdr_height > 0 && self.gm_height > 0);
 
-        let last_sdr_row = (self.current_sdr_row + num_sdr_rows - 1).min(self.sdr_height - 1);
+        let last_sdr_row = self
+            .current_sdr_row
+            .saturating_add(num_sdr_rows)
+            .saturating_sub(1)
+            .min(self.sdr_height - 1);
         let gm_y_last = (last_sdr_row as f32 / self.sdr_height as f32) * self.gm_height as f32;
         let gm_y1_needed = (gm_y_last.ceil() as u32).min(self.gm_height - 1);
 
@@ -684,14 +709,21 @@ impl RowEncoder {
         hdr_gamut: ColorPrimaries,
         sdr_gamut: ColorPrimaries,
     ) -> Result<Self> {
+        crate::types::validate_ultrahdr_dimensions(width, height)?;
         let scale = config.scale_factor.max(1) as u32;
         let gm_width = width.div_ceil(scale);
         let gm_height = height.div_ceil(scale);
+        crate::types::validate_ultrahdr_dimensions(gm_width, gm_height)?;
 
         let buffer_size = (scale as usize + 16).max(32);
         let channels = if config.multi_channel { 3 } else { 1 };
-        let gm_row_stride = gm_width as usize * channels;
-        let gainmap_data = vec![0u8; gm_row_stride * gm_height as usize];
+        let gm_row_stride = (gm_width as usize)
+            .checked_mul(channels)
+            .ok_or_else(|| Error::LimitExceeded("gainmap row stride overflow".to_string()))?;
+        let alloc_size = gm_row_stride
+            .checked_mul(gm_height as usize)
+            .ok_or_else(|| Error::LimitExceeded("gainmap allocation overflow".to_string()))?;
+        let gainmap_data = vec![0u8; alloc_size];
 
         Ok(Self {
             config,
@@ -968,11 +1000,15 @@ impl StreamEncoder {
         hdr_gamut: ColorPrimaries,
         sdr_gamut: ColorPrimaries,
     ) -> Result<Self> {
+        crate::types::validate_ultrahdr_dimensions(width, height)?;
         let scale = config.scale_factor.max(1) as u32;
         let gm_width = width.div_ceil(scale);
         let gm_height = height.div_ceil(scale);
+        crate::types::validate_ultrahdr_dimensions(gm_width, gm_height)?;
 
-        let row_floats = width as usize * 3; // RGB
+        let row_floats = (width as usize)
+            .checked_mul(3)
+            .ok_or_else(|| Error::LimitExceeded("encoder row stride overflow".to_string()))?;
         let buffer_capacity = (scale + 16).min(32);
 
         Ok(Self {
@@ -1540,6 +1576,53 @@ mod tests {
 
         assert!(decoder.is_complete());
         assert_eq!(decoder.sdr_rows_remaining(), 0);
+    }
+
+    // Regression: `can_process(0)` used to compute `0u32 - 1` in the
+    // `last_sdr_row` calculation, underflowing to `u32::MAX` (security
+    // audit 2026-05-06, finding H2). The function now early-returns
+    // for `num_sdr_rows == 0`.
+    #[test]
+    fn stream_decoder_can_process_zero_rows() {
+        let metadata = test_metadata();
+        let decoder =
+            StreamDecoder::new(metadata, 4, 4, 2, 2, 1, 4.0, ColorPrimaries::Bt709).unwrap();
+        // No gainmap data buffered yet, but `0` rows is a trivial "yes".
+        assert!(decoder.can_process(0));
+    }
+
+    // Regression: zero-dim gainmap and zero-dim SDR used to flow through
+    // `StreamDecoder::new` (security audit 2026-05-06, finding H1).
+    #[test]
+    fn stream_decoder_new_rejects_zero_dims() {
+        let metadata = test_metadata();
+        assert!(
+            StreamDecoder::new(metadata.clone(), 0, 4, 2, 2, 1, 4.0, ColorPrimaries::Bt709)
+                .is_err()
+        );
+        assert!(
+            StreamDecoder::new(metadata.clone(), 4, 4, 0, 2, 1, 4.0, ColorPrimaries::Bt709)
+                .is_err()
+        );
+        assert!(StreamDecoder::new(metadata, 4, 4, 2, 2, 5, 4.0, ColorPrimaries::Bt709).is_err());
+    }
+
+    #[test]
+    fn row_encoder_new_rejects_zero_dims() {
+        let config = GainMapConfig::default();
+        assert!(
+            RowEncoder::new(
+                0,
+                4,
+                config.clone(),
+                ColorPrimaries::Bt709,
+                ColorPrimaries::Bt709
+            )
+            .is_err()
+        );
+        assert!(
+            RowEncoder::new(4, 0, config, ColorPrimaries::Bt709, ColorPrimaries::Bt709).is_err()
+        );
     }
 
     #[test]

--- a/ultrahdr-core/src/lib.rs
+++ b/ultrahdr-core/src/lib.rs
@@ -72,8 +72,9 @@ mod types;
 pub use types::{
     ColorPrimaries, Error, GainMap, GainMapEncodingFormat, PixelBuffer, PixelFormat, PixelSlice,
     PixelSliceMut, Result, TransferFunction, clone_pixel_buffer, descriptor_for, luminance,
-    new_pixel_buffer, pixel_buffer_from_vec, require_supported_format, validate_gainmap_metadata,
-    validate_ultrahdr_dimensions, validate_ultrahdr_image, validate_ultrahdr_slice,
+    new_pixel_buffer, pixel_buffer_from_vec, require_supported_format, validate_gainmap_magnitude,
+    validate_gainmap_metadata, validate_ultrahdr_dimensions, validate_ultrahdr_image,
+    validate_ultrahdr_slice,
 };
 
 // Re-export from zencodec (canonical gain map metadata types)
@@ -109,4 +110,38 @@ pub mod limits {
 
     /// Maximum gain map metadata array length.
     pub const MAX_METADATA_ARRAY_LENGTH: usize = 1024;
+
+    /// Maximum absolute magnitude for `min` / `max` gain values
+    /// (log2 domain). Real Ultra HDR metadata never approaches ±30; the
+    /// cap exists to keep `(value * ln2) as f32` finite and the resulting
+    /// `exp()` inside `[2^-30, 2^30]` ≈ `[1e-9, 1e9]` — wider than any
+    /// HDR display will ever support, narrower than `f32` overflow.
+    pub const MAX_LOG_GAIN_MAGNITUDE: f64 = 30.0;
+
+    /// Maximum absolute magnitude for `alternate_hdr_headroom` /
+    /// `base_hdr_headroom` (log2 domain). Same rationale as
+    /// [`MAX_LOG_GAIN_MAGNITUDE`].
+    pub const MAX_HEADROOM_MAGNITUDE: f64 = 30.0;
+
+    /// Maximum absolute magnitude for `base_offset` / `alternate_offset`
+    /// (linear domain). Spec values are in `[0, 1]`; the cap is generous
+    /// to allow for non-spec-compliant metadata while still rejecting
+    /// values that would push `(sdr + offset) / gain` to `±inf`.
+    pub const MAX_OFFSET_MAGNITUDE: f64 = 16.0;
+
+    /// Maximum gamma value for gain map decoding. Spec uses values
+    /// near 1.0; `gamma > 100` produces a near-step function and risks
+    /// `powf` precision loss.
+    pub const MAX_GAMMA: f64 = 100.0;
+
+    /// Minimum gamma value (must be > 0; cap below for the same
+    /// precision-loss reason).
+    pub const MIN_GAMMA: f64 = 0.01;
+
+    /// Maximum precomputed Shepard's IDW table entries
+    /// (`scale_x * scale_y`). Practical Ultra HDR ratios never exceed
+    /// 1:16 (so `scale ≤ 16`, `scale² ≤ 256`); the cap of 4096 is
+    /// generous and keeps the four LUTs (`full`, `no_right`,
+    /// `no_bottom`, `corner`) under 256 KB combined.
+    pub const MAX_SHEPARDS_TABLE_ENTRIES: u32 = 4096;
 }

--- a/ultrahdr-core/src/types.rs
+++ b/ultrahdr-core/src/types.rs
@@ -310,6 +310,46 @@ pub struct GainMap {
 }
 
 impl GainMap {
+    /// Validate a [`GainMap`]'s field invariants.
+    ///
+    /// Constructors ([`GainMap::new`], [`GainMap::new_multichannel`])
+    /// preserve these invariants, but the fields are `pub` for serde /
+    /// codec interop, so a struct-literal `GainMap { ... }` can produce
+    /// values that violate them. Every consumer that derefs `data`
+    /// based on `width`/`height`/`channels` must call this first.
+    ///
+    /// Rejects:
+    /// * `width == 0` / `height == 0` (every sampler does
+    ///   `width - 1` arithmetic that would underflow);
+    /// * `width` / `height` above [`limits::MAX_IMAGE_DIMENSION`];
+    /// * `channels` outside `{1, 3}`;
+    /// * `data.len() < width * height * channels`.
+    pub fn validate(&self) -> Result<()> {
+        validate_ultrahdr_dimensions(self.width, self.height)?;
+        if self.channels != 1 && self.channels != 3 {
+            return Err(Error::InvalidPixelData(alloc::format!(
+                "gainmap.channels must be 1 or 3, got {}",
+                self.channels
+            )));
+        }
+        let expected = (self.width as usize)
+            .checked_mul(self.height as usize)
+            .and_then(|p| p.checked_mul(self.channels as usize))
+            .ok_or_else(|| {
+                Error::LimitExceeded(alloc::string::ToString::to_string(
+                    &"gainmap dimensions overflow usize",
+                ))
+            })?;
+        if self.data.len() < expected {
+            return Err(Error::InvalidPixelData(alloc::format!(
+                "gainmap data buffer too small: {} < {}",
+                self.data.len(),
+                expected
+            )));
+        }
+        Ok(())
+    }
+
     /// Create a new single-channel gain map.
     pub fn new(width: u32, height: u32) -> Result<Self> {
         validate_ultrahdr_dimensions(width, height)?;
@@ -355,11 +395,89 @@ pub type GainMapMetadata = zencodec::GainMapParams;
 /// Re-exported from [`zencodec::GainMapChannel`].
 pub use zencodec::GainMapChannel;
 
+/// Reject gain map metadata whose magnitude would push f32 math to
+/// `±inf` / `NaN` even though every value is `is_finite()` in f64.
+///
+/// This is a strict subset of [`validate_gainmap_metadata`] — it does
+/// NOT inherit zencodec's `min <= max` invariant, which can be
+/// violated by a few ULPs after ISO 21496-1 fraction quantization
+/// without indicating an attack. The decode-side LUT independently
+/// clamps decoded gains to a finite range, so the magnitude bound is
+/// enough on its own to prevent `+inf` / `NaN` in the output buffer.
+pub fn validate_gainmap_magnitude(metadata: &GainMapMetadata) -> Result<()> {
+    if !metadata.alternate_hdr_headroom.is_finite() || !metadata.base_hdr_headroom.is_finite() {
+        return Err(Error::InvalidMetadata("hdr headroom must be finite".into()));
+    }
+    if metadata.alternate_hdr_headroom.abs() > limits::MAX_HEADROOM_MAGNITUDE
+        || metadata.base_hdr_headroom.abs() > limits::MAX_HEADROOM_MAGNITUDE
+    {
+        return Err(Error::InvalidMetadata(alloc::format!(
+            "hdr headroom magnitude exceeds {} (log2 domain)",
+            limits::MAX_HEADROOM_MAGNITUDE
+        )));
+    }
+    for (i, ch) in metadata.channels.iter().enumerate() {
+        if !ch.min.is_finite()
+            || !ch.max.is_finite()
+            || !ch.gamma.is_finite()
+            || !ch.base_offset.is_finite()
+            || !ch.alternate_offset.is_finite()
+        {
+            return Err(Error::InvalidMetadata(alloc::format!(
+                "channel {i} contains non-finite values"
+            )));
+        }
+        if ch.min.abs() > limits::MAX_LOG_GAIN_MAGNITUDE
+            || ch.max.abs() > limits::MAX_LOG_GAIN_MAGNITUDE
+        {
+            return Err(Error::InvalidMetadata(alloc::format!(
+                "channel {} min/max magnitude exceeds {} (log2 domain)",
+                i,
+                limits::MAX_LOG_GAIN_MAGNITUDE
+            )));
+        }
+        if ch.base_offset.abs() > limits::MAX_OFFSET_MAGNITUDE
+            || ch.alternate_offset.abs() > limits::MAX_OFFSET_MAGNITUDE
+        {
+            return Err(Error::InvalidMetadata(alloc::format!(
+                "channel {} offset magnitude exceeds {} (linear domain)",
+                i,
+                limits::MAX_OFFSET_MAGNITUDE
+            )));
+        }
+        if !(limits::MIN_GAMMA..=limits::MAX_GAMMA).contains(&ch.gamma) {
+            return Err(Error::InvalidMetadata(alloc::format!(
+                "channel {} gamma must be within [{}, {}]",
+                i,
+                limits::MIN_GAMMA,
+                limits::MAX_GAMMA
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Validate gain map metadata with ultrahdr-core's stricter checks.
 ///
-/// Delegates to [`zencodec::GainMapParams::validate()`] and additionally rejects
-/// negative `alternate_hdr_headroom` (log2 domain), which the base
-/// zencodec validation does not enforce.
+/// Delegates to [`zencodec::GainMapParams::validate()`] for `is_finite`
+/// / `min ≤ max` / `gamma > 0`, then additionally rejects:
+///
+/// * `alternate_hdr_headroom < 0` (log2 domain) — base zencodec
+///   validation does not enforce sign.
+/// * `|min|`, `|max|` greater than [`limits::MAX_LOG_GAIN_MAGNITUDE`].
+///   Without this bound a finite f64 like `1e30` casts to `f32 +inf`
+///   inside the LUT and silently propagates `+inf` into the HDR
+///   output (`LinearFloat` / `LinearF16` arms write the raw float;
+///   the `Srgb8` arm clamps but is still wrong).
+/// * `|alternate_hdr_headroom|`, `|base_hdr_headroom|` greater than
+///   [`limits::MAX_HEADROOM_MAGNITUDE`] — same `2^headroom` overflow
+///   risk as `min`/`max`.
+/// * `|base_offset|`, `|alternate_offset|` greater than
+///   [`limits::MAX_OFFSET_MAGNITUDE`] — keeps
+///   `(sdr + offset) / gain - other_offset` finite.
+/// * `gamma` outside `[`[`limits::MIN_GAMMA`]`,` [`limits::MAX_GAMMA`]`]` —
+///   above-spec values either produce a near-step function (`> 100`)
+///   or saturate `powf` (`< 0.01`).
 pub fn validate_gainmap_metadata(metadata: &GainMapMetadata) -> Result<()> {
     metadata
         .validate()
@@ -368,6 +486,42 @@ pub fn validate_gainmap_metadata(metadata: &GainMapMetadata) -> Result<()> {
         return Err(Error::InvalidMetadata(
             "alternate_hdr_headroom must be >= 0.0 (log2 domain)".into(),
         ));
+    }
+    if metadata.alternate_hdr_headroom.abs() > limits::MAX_HEADROOM_MAGNITUDE
+        || metadata.base_hdr_headroom.abs() > limits::MAX_HEADROOM_MAGNITUDE
+    {
+        return Err(Error::InvalidMetadata(alloc::format!(
+            "hdr headroom magnitude exceeds {} (log2 domain)",
+            limits::MAX_HEADROOM_MAGNITUDE
+        )));
+    }
+    for (i, ch) in metadata.channels.iter().enumerate() {
+        if ch.min.abs() > limits::MAX_LOG_GAIN_MAGNITUDE
+            || ch.max.abs() > limits::MAX_LOG_GAIN_MAGNITUDE
+        {
+            return Err(Error::InvalidMetadata(alloc::format!(
+                "channel {} min/max magnitude exceeds {} (log2 domain)",
+                i,
+                limits::MAX_LOG_GAIN_MAGNITUDE
+            )));
+        }
+        if ch.base_offset.abs() > limits::MAX_OFFSET_MAGNITUDE
+            || ch.alternate_offset.abs() > limits::MAX_OFFSET_MAGNITUDE
+        {
+            return Err(Error::InvalidMetadata(alloc::format!(
+                "channel {} offset magnitude exceeds {} (linear domain)",
+                i,
+                limits::MAX_OFFSET_MAGNITUDE
+            )));
+        }
+        if !(limits::MIN_GAMMA..=limits::MAX_GAMMA).contains(&ch.gamma) {
+            return Err(Error::InvalidMetadata(alloc::format!(
+                "channel {} gamma must be within [{}, {}]",
+                i,
+                limits::MIN_GAMMA,
+                limits::MAX_GAMMA
+            )));
+        }
     }
     Ok(())
 }
@@ -675,5 +829,130 @@ mod tests {
             assert!((original.channels[ch].gamma - parsed.channels[ch].gamma).abs() < 1e-4);
         }
         assert!((original.alternate_hdr_headroom - parsed.alternate_hdr_headroom).abs() < 1e-3);
+    }
+
+    // Regression: large finite metadata values used to cast `f64 * ln2` to
+    // `f32 +inf`, propagating `+inf` into LinearFloat / LinearF16 output
+    // (security audit 2026-05-06, finding C1).
+    #[test]
+    fn validate_gainmap_magnitude_rejects_huge_finite_min_max() {
+        let metadata = make_metadata(
+            [1.0e30; 3], // log2 domain — clearly way past 30
+            [1.0e30; 3],
+            [1.0; 3],
+            [0.0; 3],
+            [0.0; 3],
+            0.0,
+            2.0,
+            true,
+            false,
+        );
+        let err = validate_gainmap_magnitude(&metadata).unwrap_err();
+        let msg = alloc::string::ToString::to_string(&err);
+        assert!(
+            msg.contains("magnitude") && msg.contains("log2"),
+            "expected magnitude/log2 message: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_gainmap_magnitude_rejects_huge_headroom() {
+        let metadata = make_metadata(
+            [0.0; 3], [2.0; 3], [1.0; 3], [0.0; 3], [0.0; 3], 0.0,
+            1.0e10, // alt headroom way past 30
+            true, false,
+        );
+        assert!(validate_gainmap_magnitude(&metadata).is_err());
+    }
+
+    #[test]
+    fn validate_gainmap_magnitude_rejects_huge_offsets() {
+        let mut metadata = make_metadata(
+            [0.0; 3], [2.0; 3], [1.0; 3],
+            [100.0; 3], // base_offset way past MAX_OFFSET_MAGNITUDE
+            [0.0; 3], 0.0, 2.0, true, false,
+        );
+        assert!(validate_gainmap_magnitude(&metadata).is_err());
+
+        metadata.channels[0].base_offset = 0.0;
+        metadata.channels[0].alternate_offset = 100.0;
+        assert!(validate_gainmap_magnitude(&metadata).is_err());
+    }
+
+    #[test]
+    fn validate_gainmap_magnitude_rejects_extreme_gamma() {
+        let metadata = make_metadata(
+            [0.0; 3],
+            [2.0; 3],
+            [1000.0, 1.0, 1.0], // gamma > MAX_GAMMA
+            [0.0; 3],
+            [0.0; 3],
+            0.0,
+            2.0,
+            true,
+            false,
+        );
+        assert!(validate_gainmap_magnitude(&metadata).is_err());
+    }
+
+    #[test]
+    fn validate_gainmap_magnitude_accepts_realistic_values() {
+        let metadata = make_metadata(
+            [-2.0, -2.0, -2.0],
+            [3.0, 3.0, 3.0],
+            [1.0, 1.0, 1.0],
+            [1.0 / 64.0; 3],
+            [1.0 / 64.0; 3],
+            0.0,
+            3.0,
+            true,
+            false,
+        );
+        assert!(validate_gainmap_magnitude(&metadata).is_ok());
+    }
+
+    // Regression: zero-dim GainMap used to underflow `width - 1` in every
+    // sampler (security audit 2026-05-06, finding C2).
+    #[test]
+    fn gainmap_validate_rejects_zero_dim() {
+        let gm = GainMap {
+            width: 0,
+            height: 4,
+            channels: 1,
+            data: alloc::vec![0u8; 0],
+        };
+        assert!(gm.validate().is_err());
+
+        let gm = GainMap {
+            width: 4,
+            height: 0,
+            channels: 1,
+            data: alloc::vec![0u8; 0],
+        };
+        assert!(gm.validate().is_err());
+    }
+
+    #[test]
+    fn gainmap_validate_rejects_bad_channels() {
+        for c in [0u8, 2, 4, 255] {
+            let gm = GainMap {
+                width: 2,
+                height: 2,
+                channels: c,
+                data: alloc::vec![0u8; 16],
+            };
+            assert!(gm.validate().is_err(), "channels={c} should be rejected");
+        }
+    }
+
+    #[test]
+    fn gainmap_validate_rejects_short_data_buffer() {
+        let gm = GainMap {
+            width: 4,
+            height: 4,
+            channels: 1,
+            data: alloc::vec![0u8; 4], // expected 16
+        };
+        assert!(gm.validate().is_err());
     }
 }

--- a/ultrahdr-rs/src/decode.rs
+++ b/ultrahdr-rs/src/decode.rs
@@ -182,7 +182,15 @@ impl<'a> Decoder<'a> {
             // First secondary image = gain map.
             let gm_entry = &mpf_entries[1];
             let gm_start = gm_entry.offset;
-            let gm_end = gm_start + gm_entry.size;
+            // `checked_add` defends against the 32-bit case where
+            // `offset + size` could wrap past `usize::MAX` and pass the
+            // `<= self.data.len()` bound check before slicing panics.
+            let gm_end = match gm_start.checked_add(gm_entry.size) {
+                Some(end) => end,
+                None => {
+                    return Err(Error::DecodeError("MPF entry offset+size overflows".into()));
+                }
+            };
             if gm_end <= self.data.len() {
                 self.gainmap_jpeg = Some((gm_start, gm_end));
                 self.is_ultrahdr = true;


### PR DESCRIPTION
## Summary

Implements the CRITICAL and HIGH findings from the 2026-05-06 security audit (`/home/lilith/work/feedback/security-audit-2026-05-06/ultrahdr.md`). Bundles eight related fixes into one PR because they share validation paths and one new public helper.

## Fixes

- **C1 + H4 + M1** — `apply.rs:30-61` (`GainMapLut::new`), `tonemap.rs:1198-1213` (`decode_gain_value`), `tonemap.rs:419-427` (`from_gainmap`): clamp decoded gain to a finite range (`exp(±30 ln2) ≈ [2^-30, 2^30]`) so attacker-controlled large finite metadata can no longer flow `+inf` / `NaN` into `LinearFloat` / `LinearF16` output. New `validate_gainmap_magnitude` runs at every apply entry point and rejects offending metadata up-front.
- **C2** — `types.rs` (`GainMap::validate`): a struct-literal `GainMap { width: 0, ... }` used to underflow every sampler's `width - 1` arithmetic. New `GainMap::validate()` also checks `channels in {1, 3}` and `data.len()` consistency. Wired into `apply_gainmap_slice`, `RowDecoder::new`, `StreamDecoder::new`, `RowEncoder::new`, `StreamEncoder::new`, `scale_gainmap`, `crop_gainmap`, `apply_with_gainmap`.
- **C3** — `apply.rs:430-449` (`ShepardsLut::new`): unchecked `u32 * u32 * 4` could either wrap or allocate ~16 GB. Switch to `checked_mul`, cap on `MAX_SHEPARDS_TABLE_ENTRIES = 4096` (covers practical Ultra HDR ratios up to 1:64), `try_new` returns `None` for pathological scales so callers fall through to the per-pixel float path. `ShepardsLut::new` is now `Option<Self>`.
- **H1** — `streaming.rs` constructors: validate dims via `validate_ultrahdr_dimensions`, use `checked_mul` for gainmap allocation size, validate `gm_channels in {1, 3}` for `StreamDecoder`.
- **H2** — `streaming.rs:456-466` (`StreamDecoder::can_process`): early-return for `num_sdr_rows == 0`; use `saturating_sub` to remove the residual underflow.
- **H3** — `tonemap.rs:874-910` (`crop_gainmap`) and `scale_gainmap`: validate input dims, require `crop_x + crop_w <= sdr_width` (checked_add), clamp `gm_x` before the subtraction. Out-of-bounds crop rects now error explicitly.
- **H5** — `decode.rs:182-187` (`Decoder::parse`): MPF `(offset + size)` switches to `checked_add` so 32-bit builds can't wrap past `usize::MAX`.

The existing `validate_gainmap_metadata` is kept (used by encoder-side callers who want full zencodec-equivalent strict checks). The new `validate_gainmap_magnitude` is the apply-side validation — strict on magnitudes/finiteness but lenient on `min ≤ max` so harmless ISO 21496-1 fraction round-trip artifacts (a few ULPs apart) don't break decode.

## Tests

17 new regression tests — one per finding plus boundary cases:

- `validate_gainmap_magnitude_rejects_huge_finite_min_max` / `huge_headroom` / `huge_offsets` / `extreme_gamma` / `accepts_realistic_values`
- `gainmap_validate_rejects_zero_dim` / `bad_channels` / `short_data_buffer`
- `shepards_lut_try_new_caps_pathological_scale` (covers 65535x1, 32768x2, 64x1, 65x1) / `rejects_zero_dims` / `new_rejects_zero_scale`
- `apply_gainmap_slice_rejects_zero_dim_gainmap`
- `gainmap_lut_clamps_large_metadata_to_finite`
- `stream_decoder_can_process_zero_rows` / `new_rejects_zero_dims`
- `row_encoder_new_rejects_zero_dims`

`test_crop_gainmap_out_of_bounds` was rewritten to assert rejection — it previously enforced the H3 buggy clamp-on-underflow behavior.

## Test plan

- [ ] `cargo test --workspace --all-targets` — all 153 ultrahdr-core lib tests + integration suites pass locally
- [ ] `cargo test --workspace --doc` — doctests pass
- [ ] `cargo clippy --all-targets` — no new warnings introduced (one pre-existing warning in `tests/libultrahdr_parity.rs` unchanged)
- [ ] Verify CI passes on `windows-11-arm`, `macos-15-intel`, `i686-unknown-linux-gnu` (especially i686 for the H5 fix)

## Deferred to follow-up

MEDIUM and LOW findings (M2-M6, L1-L5) are out of scope for this PR per the audit's CRITICAL/HIGH-only directive. Notable items to track:

- **M5** — `extract_icc_profile` should defer to `container::scan_segments` instead of its hand-rolled walker.
- **M6** — additional channels-count validation in apply path (covered partially by `GainMap::validate()` but not exhaustive).
- Audit recommendations 9/10/11 — expand fuzz target dim caps, add streaming-type fuzz target, add `scale_gainmap`/`crop_gainmap` fuzz target.

Reference: `/home/lilith/work/feedback/security-audit-2026-05-06/ultrahdr.md`