### PR TITLE
Reject invalid half-float HDR transfers

### DIFF
--- a/ultrahdr-core/src/gainmap/compute.rs
+++ b/ultrahdr-core/src/gainmap/compute.rs
@@ -132,6 +132,7 @@ pub fn compute_gainmap_slice(
     // Clamp actual values to configured range
     actual_min_boost = actual_min_boost.max(config.min_boost);
     actual_max_boost = actual_max_boost.min(config.max_boost);
+    actual_min_boost = actual_min_boost.min(actual_max_boost);
 
     // Build metadata (convert linear boost values to log2 domain)
     let metadata = crate::types::metadata_from_arrays(
@@ -741,6 +742,26 @@ mod tests {
             avg > 128.0,
             "bright HDR should produce high gainmap values, got average {}",
             avg
+        );
+    }
+
+    #[test]
+    fn test_compute_gainmap_metadata_stays_valid_when_all_gains_clip_high() {
+        let hdr = make_hdr_8x8(100.0, 100.0, 100.0);
+        let sdr = make_sdr_8x8(255, 255, 255);
+        let config = GainMapConfig {
+            max_boost: 10000.0 / 203.0,
+            ..Default::default()
+        };
+
+        let (_gainmap, metadata) =
+            compute_gainmap(&hdr, &sdr, &config, enough::Unstoppable).unwrap();
+
+        assert!(
+            metadata.channels[0].min <= metadata.channels[0].max,
+            "metadata min must not exceed max: {} > {}",
+            metadata.channels[0].min,
+            metadata.channels[0].max
         );
     }
 

--- a/ultrahdr-rs/src/encode.rs
+++ b/ultrahdr-rs/src/encode.rs
@@ -3,7 +3,10 @@
 use ultrahdr_core::color::tonemap::tonemap_image_to_srgb8;
 
 use ultrahdr_core::gainmap::compute::{GainMapConfig, compute_gainmap};
-use ultrahdr_core::{ColorPrimaries, Error, GainMapEncodingFormat, GainMapMetadata, Result};
+use ultrahdr_core::{
+    ColorPrimaries, Error, GainMapEncodingFormat, GainMapMetadata, Result,
+    validate_gainmap_metadata,
+};
 
 use ultrahdr_core::{PixelFormat, TransferFunction, Unstoppable};
 
@@ -103,6 +106,8 @@ pub fn encode_ultrahdr_with_format(
     gamut: ColorPrimaries,
     format: GainMapEncodingFormat,
 ) -> Result<Vec<u8>> {
+    validate_gainmap_metadata(metadata)?;
+
     // Build metadata markers for the gain map JPEG (XMP and/or ISO 21496-1).
     let metadata_markers = build_gainmap_metadata_markers(metadata, format);
 
@@ -335,12 +340,15 @@ impl Encoder {
         if let (Some(gainmap_jpeg), Some(metadata)) =
             (&self.existing_gainmap_jpeg, &self.existing_metadata)
         {
+            validate_gainmap_metadata(metadata)?;
+
             let (base_jpeg, gamut) = if let Some(ref compressed) = self.compressed_sdr {
                 (compressed.clone(), ColorPrimaries::Bt709)
             } else if let Some(ref sdr_img) = self.sdr_image {
                 let gamut = sdr_img.descriptor().primaries;
                 (self.encode_base_jpeg(sdr_img)?, gamut)
             } else if let Some(ref hdr) = self.hdr_image {
+                validate_hdr_input_for_encode(hdr)?;
                 let sdr_pixels = tonemap_image_to_srgb8(hdr, ColorPrimaries::Bt709)?;
                 let sdr = pixel_buffer_from_vec(
                     sdr_pixels,
@@ -366,6 +374,7 @@ impl Encoder {
             .hdr_image
             .as_ref()
             .ok_or_else(|| Error::EncodeError("HDR image is required".into()))?;
+        validate_hdr_input_for_encode(hdr)?;
 
         // Generate or use provided SDR
         let sdr: PixelBuffer = if let Some(ref sdr_img) = self.sdr_image {
@@ -395,6 +404,7 @@ impl Encoder {
                     && gm.height <= expected_height + 1;
 
                 if width_ok && height_ok {
+                    validate_gainmap_metadata(meta)?;
                     (gm.clone(), meta.clone())
                 } else {
                     self.compute_new_gainmap(hdr, &sdr)?
@@ -433,6 +443,7 @@ impl Encoder {
             .existing_metadata
             .as_ref()
             .ok_or_else(|| Error::EncodeError("Metadata not set".into()))?;
+        validate_gainmap_metadata(metadata)?;
 
         encode_ultrahdr(base_jpeg, gainmap_jpeg, metadata, ColorPrimaries::Bt709)
     }
@@ -443,12 +454,16 @@ impl Encoder {
         hdr: &PixelBuffer,
         sdr: &PixelBuffer,
     ) -> Result<(GainMap, GainMapMetadata)> {
+        let full_hdr10_boost = 10000.0 / 203.0;
+        let max_boost = (self.target_display_peak / 203.0)
+            .max(full_hdr10_boost)
+            .max(self.gain_map_min);
         let config = GainMapConfig {
             scale_factor: self.gainmap_scale,
             gamma: 1.0,
             multi_channel: false,
             min_boost: self.gain_map_min,
-            max_boost: self.target_display_peak / 203.0,
+            max_boost,
             base_offset: 1.0 / 64.0,
             alternate_offset: 1.0 / 64.0,
             base_hdr_headroom: 1.0, // linear: 1.0 = no boost → log2 = 0.0
@@ -503,6 +518,23 @@ impl Encoder {
             .map_err(|e| Error::JpegEncode(e.to_string()))?;
         enc.finish().map_err(|e| Error::JpegEncode(e.to_string()))
     }
+}
+
+fn validate_hdr_input_for_encode(hdr: &PixelBuffer) -> Result<()> {
+    let desc = hdr.descriptor();
+    let format = desc.pixel_format();
+    let transfer = desc.transfer();
+
+    if matches!(format, PixelFormat::RgbaF16 | PixelFormat::RgbF16)
+        && transfer != TransferFunction::Linear
+    {
+        return Err(Error::EncodeError(format!(
+            "invalid HDR input transfer {:?} for {:?}; half-float HDR input requires TransferFunction::Linear",
+            transfer, format
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/ultrahdr-rs/tests/common.rs
+++ b/ultrahdr-rs/tests/common.rs
@@ -41,6 +41,39 @@ pub fn create_hdr_gradient(width: u32, height: u32, peak_brightness: f32) -> Pix
     .unwrap()
 }
 
+/// Create an HDR gradient image in RGBA half-float format with chosen transfer.
+pub fn create_hdr_f16_gradient_with_transfer(
+    width: u32,
+    height: u32,
+    peak_brightness: f32,
+    transfer: TransferFunction,
+) -> PixelBuffer {
+    let mut data = Vec::with_capacity((width * height * 8) as usize);
+
+    for _y in 0..height {
+        for x in 0..width {
+            let t = x as f32 / (width - 1).max(1) as f32;
+            let value = half::f16::from_f32(t * peak_brightness).to_le_bytes();
+            let alpha = half::f16::ONE.to_le_bytes();
+
+            data.extend_from_slice(&value);
+            data.extend_from_slice(&value);
+            data.extend_from_slice(&value);
+            data.extend_from_slice(&alpha);
+        }
+    }
+
+    pixel_buffer_from_vec(
+        data,
+        width,
+        height,
+        PixelFormat::RgbaF16,
+        ColorPrimaries::Bt709,
+        transfer,
+    )
+    .unwrap()
+}
+
 /// Create an SDR gradient image for testing.
 pub fn create_sdr_gradient(width: u32, height: u32) -> PixelBuffer {
     let mut data = Vec::with_capacity((width * height * 4) as usize);

--- a/ultrahdr-rs/tests/encode_basic.rs
+++ b/ultrahdr-rs/tests/encode_basic.rs
@@ -5,10 +5,11 @@
 mod common;
 
 use common::{
-    create_hdr_checkerboard, create_hdr_gradient, create_hdr_solid, create_sdr_checkerboard,
-    create_sdr_gradient, create_sdr_solid,
+    create_hdr_checkerboard, create_hdr_f16_gradient_with_transfer, create_hdr_gradient,
+    create_hdr_solid, create_sdr_checkerboard, create_sdr_gradient, create_sdr_solid,
+    create_test_metadata,
 };
-use ultrahdr_rs::{Decoder, Encoder, clone_pixel_buffer};
+use ultrahdr_rs::{Decoder, Encoder, GainMap, TransferFunction, clone_pixel_buffer};
 
 /// Test encoding with HDR-only input (auto-generates SDR).
 #[test]
@@ -25,6 +26,59 @@ fn test_encode_hdr_only() {
     // Verify it's a valid Ultra HDR
     let decoder = Decoder::new(&encoded).unwrap();
     assert!(decoder.is_ultrahdr(), "Output should be Ultra HDR");
+}
+
+/// libultrahdr API 0 accepts RGBA half-float HDR input only with Linear transfer.
+#[test]
+fn test_encode_accepts_rgba_f16_linear_hdr() {
+    let hdr = create_hdr_f16_gradient_with_transfer(64, 64, 4.0, TransferFunction::Linear);
+    let sdr = create_sdr_gradient(64, 64);
+
+    let mut encoder = Encoder::new();
+    encoder.set_hdr_image(hdr).set_sdr_image(sdr);
+
+    let encoded = encoder.encode().unwrap();
+    assert!(Decoder::new(&encoded).unwrap().is_ultrahdr());
+}
+
+/// libultrahdr API 0 rejects RGBA half-float paired with PQ/HLG transfer.
+#[test]
+fn test_encode_rejects_rgba_f16_pq_or_hlg_hdr() {
+    for transfer in [TransferFunction::Pq, TransferFunction::Hlg] {
+        let hdr = create_hdr_f16_gradient_with_transfer(64, 64, 1.0, transfer);
+        let sdr = create_sdr_gradient(64, 64);
+
+        let mut encoder = Encoder::new();
+        encoder.set_hdr_image(hdr).set_sdr_image(sdr);
+
+        let err = encoder.encode().unwrap_err().to_string();
+        assert!(
+            err.contains("half-float HDR input requires TransferFunction::Linear"),
+            "unexpected error for {transfer:?}: {err}"
+        );
+    }
+}
+
+/// Invalid existing metadata must not be serialized into an UltraHDR output.
+#[test]
+fn test_encode_rejects_invalid_existing_gainmap_metadata() {
+    let hdr = create_hdr_gradient(64, 64, 4.0);
+    let sdr = create_sdr_gradient(64, 64);
+    let gainmap = GainMap::new(16, 16).unwrap();
+    let mut metadata = create_test_metadata(4.0);
+    metadata.channels[0].max = -1.0;
+
+    let mut encoder = Encoder::new();
+    encoder
+        .set_hdr_image(hdr)
+        .set_sdr_image(sdr)
+        .set_existing_gainmap(gainmap, metadata);
+
+    let err = encoder.encode().unwrap_err().to_string();
+    assert!(
+        err.contains("min must be <= max") || err.contains("invalid metadata"),
+        "unexpected error: {err}"
+    );
 }
 
 /// Test encoding with HDR + SDR input.


### PR DESCRIPTION
## Summary
- reject RgbaF16/RgbF16 HDR input unless transfer is Linear
- validate generated/provided gain-map metadata before writing
- keep generated metadata valid when all gains clip high

## Tests
- cargo test -p ultrahdr-core --offline
- cargo test -p ultrahdr-rs --offline