### PR TITLE
Honor ISO metadata toggle

### DIFF
--- a/ultrahdr-rs/src/encode.rs
+++ b/ultrahdr-rs/src/encode.rs
@@ -329,6 +329,14 @@ impl Encoder {
         self
     }
 
+    fn metadata_format(&self) -> GainMapEncodingFormat {
+        if self.use_iso_metadata {
+            GainMapEncodingFormat::Both
+        } else {
+            GainMapEncodingFormat::Xmp
+        }
+    }
+
     /// Encode to Ultra HDR JPEG.
     pub fn encode(&self) -> Result<Vec<u8>> {
         // Fast path: if we have raw gain map JPEG bytes, skip gain map processing
@@ -358,7 +366,13 @@ impl Encoder {
                 ));
             };
 
-            return encode_ultrahdr(&base_jpeg, gainmap_jpeg, metadata, gamut);
+            return encode_ultrahdr_with_format(
+                &base_jpeg,
+                gainmap_jpeg,
+                metadata,
+                gamut,
+                self.metadata_format(),
+            );
         }
 
         // Validate inputs
@@ -414,7 +428,13 @@ impl Encoder {
         let gainmap_jpeg = self.encode_gainmap_jpeg(&gainmap)?;
 
         let gamut = sdr.descriptor().primaries;
-        encode_ultrahdr(&base_jpeg, &gainmap_jpeg, &metadata, gamut)
+        encode_ultrahdr_with_format(
+            &base_jpeg,
+            &gainmap_jpeg,
+            &metadata,
+            gamut,
+            self.metadata_format(),
+        )
     }
 
     /// Encode to Ultra HDR JPEG from pre-set JPEGs (production API).
@@ -434,7 +454,13 @@ impl Encoder {
             .as_ref()
             .ok_or_else(|| Error::EncodeError("Metadata not set".into()))?;
 
-        encode_ultrahdr(base_jpeg, gainmap_jpeg, metadata, ColorPrimaries::Bt709)
+        encode_ultrahdr_with_format(
+            base_jpeg,
+            gainmap_jpeg,
+            metadata,
+            ColorPrimaries::Bt709,
+            self.metadata_format(),
+        )
     }
 
     /// Compute a new gain map.

--- a/ultrahdr-rs/tests/encode_basic.rs
+++ b/ultrahdr-rs/tests/encode_basic.rs
@@ -233,9 +233,27 @@ fn test_encode_iso_metadata_toggle() {
         .set_use_iso_metadata(false);
     let without_iso = encoder.encode().unwrap();
 
+    let iso_urn = zencodec::gainmap::ISO_21496_1_URN;
+    assert!(
+        with_iso
+            .windows(iso_urn.len())
+            .any(|window| window == iso_urn),
+        "ISO metadata should be present when enabled"
+    );
+    assert!(
+        !without_iso
+            .windows(iso_urn.len())
+            .any(|window| window == iso_urn),
+        "ISO metadata should be absent when disabled"
+    );
+
     // Both should be valid Ultra HDR
-    assert!(Decoder::new(&with_iso).unwrap().is_ultrahdr());
-    assert!(Decoder::new(&without_iso).unwrap().is_ultrahdr());
+    let with_iso_decoder = Decoder::new(&with_iso).unwrap();
+    let without_iso_decoder = Decoder::new(&without_iso).unwrap();
+    assert!(with_iso_decoder.is_ultrahdr());
+    assert!(without_iso_decoder.is_ultrahdr());
+    assert!(with_iso_decoder.metadata().is_some());
+    assert!(without_iso_decoder.metadata().is_some());
 }
 
 /// Test that encoding without HDR image fails.


### PR DESCRIPTION
## Summary
- route Encoder output through format selection from set_use_iso_metadata
- keep enabled behavior as XMP+ISO and disabled behavior as XMP-only
- assert disabled output has no ISO URN but still decodes via XMP

## Tests
- cargo test -p ultrahdr-rs --offline