### PR TITLE
Decode ISO 21496 gain-map metadata fallback

### DIFF
--- a/ultrahdr-rs/src/decode.rs
+++ b/ultrahdr-rs/src/decode.rs
@@ -2,9 +2,10 @@
 
 use ultrahdr_core::gainmap::apply::{HdrOutputFormat, apply_gainmap};
 use ultrahdr_core::{
-    ColorPrimaries, Error, GainMap, GainMapMetadata, PixelBuffer, PixelFormat, Result,
-    TransferFunction, Unstoppable, pixel_buffer_from_vec,
+    ColorPrimaries, Error, GainMap, GainMapMetadata, Iso21496Format, PixelBuffer, PixelFormat,
+    Result, TransferFunction, Unstoppable, parse_iso21496_fmt, pixel_buffer_from_vec,
 };
+use zencodec::gainmap::{ISO_21496_1_PRIMARY_APP2_BODY, ISO_21496_1_URN};
 use zenjpeg::container::marker::find_jpeg_boundaries;
 use zenjpeg::container::xmp::parse_xmp;
 
@@ -163,6 +164,12 @@ impl<'a> Decoder<'a> {
                 self.metadata = Some(metadata);
             }
         }
+        if self.metadata.is_none()
+            && let Some(metadata) = find_iso21496_metadata_in_segments(&segments)
+        {
+            self.is_ultrahdr = true;
+            self.metadata = Some(metadata);
+        }
 
         // Try to parse MPF to find gain map.
         let mpf_entries = container::parse_mpf(self.data)?;
@@ -205,6 +212,10 @@ impl<'a> Decoder<'a> {
                         && let Ok((gm_metadata, _)) = parse_xmp(&gm_xmp)
                     {
                         self.metadata = Some(gm_metadata);
+                    } else if let Some(gm_metadata) =
+                        find_iso21496_metadata_in_segments(&gm_segments)
+                    {
+                        self.metadata = Some(gm_metadata);
                     }
                 }
             }
@@ -225,6 +236,10 @@ impl<'a> Decoder<'a> {
                     if let Some(gm_xmp) = find_xmp_in_segments(&gm_segments)
                         && gm_xmp.contains("hdrgm:")
                         && let Ok((gm_metadata, _)) = parse_xmp(&gm_xmp)
+                    {
+                        self.metadata = Some(gm_metadata);
+                    } else if let Some(gm_metadata) =
+                        find_iso21496_metadata_in_segments(&gm_segments)
                     {
                         self.metadata = Some(gm_metadata);
                     }
@@ -250,6 +265,22 @@ impl<'a> Decoder<'a> {
         let sdr = self.decode_sdr()?;
         Ok((sdr.width(), sdr.height()))
     }
+}
+
+/// Find ISO 21496-1 gain-map metadata in JPEG APP2 segments.
+///
+/// The primary JPEG can contain a version-only ISO marker with the same URN.
+/// That marker advertises ISO awareness, but has no gain-map payload, so it is
+/// intentionally skipped here.
+fn find_iso21496_metadata_in_segments(segments: &[AppSegment]) -> Option<GainMapMetadata> {
+    segments
+        .iter()
+        .filter(|segment| segment.marker_num == 2)
+        .filter(|segment| segment.data.starts_with(ISO_21496_1_URN))
+        .filter(|segment| segment.data.as_slice() != ISO_21496_1_PRIMARY_APP2_BODY)
+        .find_map(|segment| {
+            parse_iso21496_fmt(&segment.data, Iso21496Format::JpegApp2BodyWithUrn).ok()
+        })
 }
 
 /// Find XMP data in pre-scanned APP segments.

--- a/ultrahdr-rs/tests/metadata_compliance.rs
+++ b/ultrahdr-rs/tests/metadata_compliance.rs
@@ -5,7 +5,20 @@
 mod common;
 
 use common::{create_hdr_gradient, create_sdr_gradient, create_test_metadata};
-use ultrahdr_rs::{Decoder, Encoder, GainMapMetadata};
+use ultrahdr_rs::{
+    ColorPrimaries, Decoder, Encoder, GainMapEncodingFormat, GainMapMetadata,
+    encode_ultrahdr_with_format,
+};
+
+/// Simplest possible JPEG for structure tests.
+fn stub_jpeg() -> Vec<u8> {
+    vec![
+        0xFF, 0xD8, // SOI
+        0xFF, 0xE0, 0x00, 0x07, // APP0, length 7
+        b'J', b'F', b'I', b'F', 0x00, // JFIF
+        0xFF, 0xD9, // EOI
+    ]
+}
 
 // ============================================================================
 // Phase 4.1: XMP Serialization Tests
@@ -293,6 +306,68 @@ fn test_iso21496_rejects_invalid() {
         ultrahdr_rs::Iso21496Format::AvifTmap,
     );
     assert!(result.is_err());
+}
+
+/// Test ISO-only Ultra HDR parses gain-map metadata without XMP gain-map metadata.
+#[test]
+fn test_decoder_reads_iso21496_metadata_when_xmp_absent() {
+    let metadata = create_test_metadata(4.0);
+    let encoded = encode_ultrahdr_with_format(
+        &stub_jpeg(),
+        &stub_jpeg(),
+        &metadata,
+        ColorPrimaries::Bt709,
+        GainMapEncodingFormat::Iso21496,
+    )
+    .unwrap();
+
+    let boundaries = zenjpeg::container::marker::find_jpeg_boundaries(&encoded);
+    assert!(
+        boundaries.len() >= 2,
+        "fixture should contain secondary JPEG"
+    );
+    let gainmap_text = String::from_utf8_lossy(&encoded[boundaries[1].clone()]);
+    assert!(
+        !gainmap_text.contains("hdrgm:"),
+        "ISO-only gain map must not contain hdrgm numeric XMP metadata"
+    );
+
+    let iso_urn = zencodec::gainmap::ISO_21496_1_URN;
+    assert!(
+        encoded
+            .windows(iso_urn.len())
+            .any(|window| window == iso_urn),
+        "ISO-only fixture should contain ISO 21496-1 APP2 metadata"
+    );
+
+    let decoder = Decoder::new(&encoded).unwrap();
+    assert!(decoder.is_ultrahdr());
+
+    let parsed = decoder
+        .metadata()
+        .expect("ISO-only metadata should be parsed");
+    assert!(
+        (parsed.channels[0].max - metadata.channels[0].max).abs() < 0.02,
+        "max boost mismatch: {} vs {}",
+        parsed.channels[0].max,
+        metadata.channels[0].max
+    );
+    assert!(
+        (parsed.channels[0].min - metadata.channels[0].min).abs() < 0.02,
+        "min boost mismatch: {} vs {}",
+        parsed.channels[0].min,
+        metadata.channels[0].min
+    );
+    assert!(
+        (parsed.alternate_hdr_headroom - metadata.alternate_hdr_headroom).abs() < 0.02,
+        "HDR headroom mismatch: {} vs {}",
+        parsed.alternate_hdr_headroom,
+        metadata.alternate_hdr_headroom
+    );
+    assert_eq!(
+        parsed.use_base_color_space, metadata.use_base_color_space,
+        "use_base_color_space mismatch"
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- scan APP2 ISO 21496-1 bodies when XMP gain-map metadata is absent
- skip the primary version-only ISO marker
- preserve XMP precedence and cover ISO-only Ultra HDR metadata decode

## Tests
- cargo test -p ultrahdr-rs --offline